### PR TITLE
feat: pass owned `self` to `execute`

### DIFF
--- a/packages/clipanion-derive/src/macros/cli_exec_async.rs
+++ b/packages/clipanion-derive/src/macros/cli_exec_async.rs
@@ -26,7 +26,7 @@ pub fn cli_exec_async_macro(types: Punctuated<syn::Path, syn::Token![,]>, enum_i
         #enum_item
 
         impl ::clipanion::details::CommandExecutorAsync for #enum_ident {
-            async fn execute(&self, env: &::clipanion::advanced::Environment) -> ::clipanion::details::CommandResult {
+            async fn execute(self, env: &::clipanion::advanced::Environment) -> ::clipanion::details::CommandResult {
                 match self {
                     #(#match_arms)*
                 }

--- a/packages/clipanion-derive/src/macros/cli_exec_sync.rs
+++ b/packages/clipanion-derive/src/macros/cli_exec_sync.rs
@@ -26,7 +26,7 @@ pub fn cli_exec_sync_macro(types: Punctuated<syn::Path, syn::Token![,]>, enum_it
         #enum_item
 
         impl ::clipanion::details::CommandExecutor for #enum_ident {
-            fn execute(&self, env: &::clipanion::advanced::Environment) -> ::clipanion::details::CommandResult {
+            fn execute(self, env: &::clipanion::advanced::Environment) -> ::clipanion::details::CommandResult {
                 match self {
                     #(#match_arms)*
                 }

--- a/packages/clipanion/src/details.rs
+++ b/packages/clipanion/src/details.rs
@@ -126,9 +126,9 @@ pub trait CommandProvider {
 }
 
 pub trait CommandExecutor {
-    fn execute(&self, env: &Environment) -> crate::details::CommandResult;
+    fn execute(self, env: &Environment) -> crate::details::CommandResult;
 }
 
 pub trait CommandExecutorAsync {
-    fn execute(&self, env: &Environment) -> impl Future<Output = crate::details::CommandResult>;
+    fn execute(self, env: &Environment) -> impl Future<Output = crate::details::CommandResult>;
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
This PR makes the `execute` method of `CommandExecutor`s take an owned `self` instead of `&self`.

This enables the `executor` to own its argument values, avoiding the need to almost always clone the values.