### PR TITLE
fix: set optional boolean field to `Some(false)` when using  `--no-`

### DIFF
--- a/packages/clipanion-derive/src/macros/command.rs
+++ b/packages/clipanion-derive/src/macros/command.rs
@@ -24,7 +24,7 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
 
     let mut builder = vec![];
     let mut hydraters = vec![];
-    
+
     let mut command_cli_attributes
         = CliAttributes::extract(&mut input.attrs)?;
 
@@ -215,7 +215,7 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                             }).transpose()?.unwrap()
                         });
                     }
-    
+
                     quote! {
                         args.chunks(#item_count).map(|chunk| -> Result<_, clipanion::core::CommandError> {
                             Ok((#(#tuple_fields),*))
@@ -347,7 +347,7 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                     let no_option_name_lit
                         = LitStr::new(&no_option_name, Span::call_site());
 
-                    if is_option_type || is_vec_type {
+                    if is_vec_type || (is_option_type && !is_bool) {
                         hydraters.push(quote! {
                             partial.#field_ident = Default::default();
                         });

--- a/packages/clipanion/tests/command_negated_options.rs
+++ b/packages/clipanion/tests/command_negated_options.rs
@@ -8,6 +8,9 @@ pub struct MyCommand {
     #[cli::option("--my-option-default-true", default = true)]
     value_default_true: bool,
 
+    #[cli::option("--my-option-default-none")]
+    value_default_none: Option<bool>,
+
     #[cli::option("--my-option-string")]
     value_string: Option<String>,
 }
@@ -33,6 +36,10 @@ test_cli_success!(it_supports_negated_options_override_true, MyCli, MyCommand, &
 
 test_cli_success!(it_supports_negated_options_default_true, MyCli, MyCommand, &["--no-my-option-default-true"], |command| {
     assert_eq!(command.value_default_true, false);
+});
+
+test_cli_success!(it_supports_negated_options_default_none, MyCli, MyCommand, &["--no-my-option-default-none"], |command| {
+    assert_eq!(command.value_default_none, Some(false));
 });
 
 test_cli_success!(it_supports_negated_options_string, MyCli, MyCommand, &["--my-option-string", "foo", "--no-my-option-string"], |command| {


### PR DESCRIPTION
When having an optional boolean option:
```
#[cli::option("--immutable")]
immutable: Option<bool>,
```

`--no-immutable`'s hydrater would set `immutable` to `None`, making it impossible to distinguish whether the option is missing or explicitly set to `false`.

This PR makes it so that `--no-` on boolean options sets the corresponding fields to `Some(false)` instead.