### PR TITLE
Implements batch options

### DIFF
--- a/packages/clipanion-core/src/selector.rs
+++ b/packages/clipanion-core/src/selector.rs
@@ -4,6 +4,7 @@ use itertools::Itertools;
 
 use crate::{shared::SUCCESS_NODE_ID, BuiltinCommand, CommandError, CommandSpec, Component, Error, State};
 
+#[derive(Debug)]
 pub enum SelectionResult<'cmds, 'args, T> {
     Builtin(BuiltinCommand<'cmds>),
     Command(&'cmds CommandSpec, State<'args>, T),

--- a/packages/clipanion/tests/command_bool_options.rs
+++ b/packages/clipanion/tests/command_bool_options.rs
@@ -1,0 +1,32 @@
+use clipanion::{prelude::*, program, test_cli_success};
+
+#[cli::command(default)]
+struct MyCommand {
+    #[cli::option("-D,--development", default = false)]
+    development: bool,
+
+    #[cli::option("-P,--production", default = false)]
+    production: bool,
+
+    #[cli::option("-T,--test", default = false)]
+    test: bool,
+}
+
+impl MyCommand {
+    fn execute(&self) {
+    }
+}
+
+program!(MyCli, [MyCommand]);
+
+test_cli_success!(it_works, MyCli, MyCommand, &["-DP"], |command| {
+    assert_eq!(command.development, true);
+    assert_eq!(command.production, true);
+    assert_eq!(command.test, false);
+});
+
+test_cli_success!(it_works_with_no_args, MyCli, MyCommand, &["-PTD"], |command| {
+    assert_eq!(command.development, true);
+    assert_eq!(command.production, true);
+    assert_eq!(command.test, true);
+});


### PR DESCRIPTION
This PR adds support for batch options to Clipanion (ie `-VP` should be treated as `-V -P`).