### PR TITLE
Implements completion commands

### DIFF
--- a/packages/clipanion-core/src/builder.rs
+++ b/packages/clipanion-core/src/builder.rs
@@ -386,7 +386,7 @@ impl<'args> DeriveState<'args, State<'args>> for Reducer {
 type Machine<'cmds>
     = machine::Machine<'cmds, Option<Check<'cmds>>, Option<Reducer>>;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase", tag = "positionalType"))]
 #[cfg_attr(feature = "serde", derive(ts_rs::TS))]
@@ -405,8 +405,26 @@ pub enum PositionalSpec {
 
         is_prefix: bool,
         is_proxy: bool,
+
+        #[cfg_attr(feature = "serde", serde(skip))]
+        completer: Option<fn(&str) -> Vec<crate::completion::Completion>>,
     },
 }
+
+impl PartialEq for PositionalSpec {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (PositionalSpec::Keyword { expected: a }, PositionalSpec::Keyword { expected: b }) => a == b,
+            (
+                PositionalSpec::Dynamic { name: a_name, documentation: a_doc, min_len: a_min, extra_len: a_extra, is_prefix: a_prefix, is_proxy: a_proxy, .. },
+                PositionalSpec::Dynamic { name: b_name, documentation: b_doc, min_len: b_min, extra_len: b_extra, is_prefix: b_prefix, is_proxy: b_proxy, .. },
+            ) => a_name == b_name && a_doc == b_doc && a_min == b_min && a_extra == b_extra && a_prefix == b_prefix && a_proxy == b_proxy,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PositionalSpec {}
 
 fn format_range(f: &mut std::fmt::Formatter<'_>, name: &str, min_len: usize, extra_len: Option<usize>) -> std::fmt::Result {
     if min_len > 0 {
@@ -478,6 +496,7 @@ impl PositionalSpec {
 
             is_prefix: false,
             is_proxy: false,
+            completer: None,
         }
     }
 
@@ -492,6 +511,7 @@ impl PositionalSpec {
 
             is_prefix: false,
             is_proxy: false,
+            completer: None,
         }
     }
 
@@ -506,6 +526,7 @@ impl PositionalSpec {
 
             is_prefix: false,
             is_proxy: false,
+            completer: None,
         }
     }
 
@@ -520,6 +541,7 @@ impl PositionalSpec {
 
             is_prefix: false,
             is_proxy: true,
+            completer: None,
         }
     }
 }

--- a/packages/clipanion-core/src/builder.rs
+++ b/packages/clipanion-core/src/builder.rs
@@ -407,7 +407,7 @@ pub enum PositionalSpec {
         is_proxy: bool,
 
         #[cfg_attr(feature = "serde", serde(skip))]
-        completer: Option<fn(&str) -> Vec<crate::completion::Completion>>,
+        completer: Option<fn(&crate::completion::CompletionContext) -> Vec<crate::completion::Completion>>,
     },
 }
 

--- a/packages/clipanion-core/src/builder.rs
+++ b/packages/clipanion-core/src/builder.rs
@@ -13,6 +13,20 @@ pub enum BuiltinCommand<'cmds, 'args> {
     Tokenize(Vec<&'args str>),
     Version,
     Help(Vec<&'cmds CommandSpec>),
+    /// Generate shell completion script
+    CompletionScript {
+        /// The shell to generate a script for (bash, zsh, fish)
+        shell: Option<String>,
+        /// The command to invoke for completions (defaults to the binary name)
+        command: Option<String>,
+    },
+    /// Compute completions for the given context
+    Complete {
+        /// The index of the argument being completed (0-based)
+        index: usize,
+        /// All arguments from the command line
+        args: Vec<&'args str>,
+    },
 }
 
 #[derive(Debug, Clone)]

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -195,7 +195,16 @@ pub fn compute_completions<'cmds, 'args>(
 
                             if let Some(id) = component_id {
                                 if let Some(Component::Positional(PositionalSpec::Dynamic { completer: Some(f), .. })) = cmd.components.get(id) {
-                                    for c in f(context.current) {
+                                    // Build a context local to this positional: only include
+                                    // values already consumed by this specific component.
+                                    let positional_args: Vec<&str> = state.positional_values.iter()
+                                        .filter(|(cid, _)| *cid == id)
+                                        .flat_map(|(_, values)| values.iter().map(|v| v.value))
+                                        .collect();
+
+                                    let local_context = CompletionContext::new(positional_args, context.current);
+
+                                    for c in f(&local_context) {
                                         completions.insert(c);
                                     }
                                 }
@@ -653,10 +662,10 @@ mod tests {
         assert!(script.contains("complete -F _my-cli_completions my-cli"));
     }
 
-    fn branch_completer(current: &str) -> Vec<Completion> {
+    fn branch_completer(ctx: &CompletionContext) -> Vec<Completion> {
         let branches = vec!["main", "develop", "feature/login", "feature/search"];
         branches.into_iter()
-            .filter(|b| b.starts_with(current))
+            .filter(|b| b.starts_with(ctx.current))
             .map(|b| Completion::new(b))
             .collect()
     }
@@ -742,10 +751,10 @@ mod tests {
         assert!(result.completions.is_empty());
     }
 
-    fn script_completer(current: &str) -> Vec<Completion> {
+    fn script_completer(ctx: &CompletionContext) -> Vec<Completion> {
         let scripts = vec!["build", "test", "lint", "start"];
         scripts.into_iter()
-            .filter(|s| s.starts_with(current))
+            .filter(|s| s.starts_with(ctx.current))
             .map(|s| Completion::new(s))
             .collect()
     }
@@ -802,5 +811,495 @@ mod tests {
         let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"build"));
         assert!(texts.contains(&"test"));
+    }
+
+    /// Completer that echoes back the args_before it receives, so we can verify
+    /// that the engine slices the context correctly for proxy positionals.
+    fn echo_context_completer(ctx: &CompletionContext) -> Vec<Completion> {
+        // Return each prior arg as a completion, plus "current:<current>" to verify
+        let mut result: Vec<Completion> = ctx.args_before.iter()
+            .map(|a| Completion::new(format!("before:{}", a)))
+            .collect();
+        result.push(Completion::new(format!("current:{}", ctx.current)));
+        result
+    }
+
+    #[test]
+    fn test_proxy_completer_receives_local_context() {
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(echo_context_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // First proxy arg: completer should see no prior args
+        // Full command: `run <TAB>` → args_before for completer = []
+        let context = CompletionContext::new(vec!["run"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"current:"));
+        assert!(!texts.iter().any(|t| t.starts_with("before:")));
+
+        // Second proxy arg: completer should see only the first proxy arg
+        // Full command: `run my-script <TAB>` → args_before for completer = ["my-script"]
+        let context = CompletionContext::new(vec!["run", "my-script"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"before:my-script"));
+        assert!(texts.contains(&"current:"));
+
+        // Third proxy arg with partial: completer should see two prior proxy args
+        // Full command: `run my-script --foo --b` → args_before for completer = ["my-script", "--foo"]
+        let context = CompletionContext::new(vec!["run", "my-script", "--foo"], "--b");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"before:my-script"));
+        assert!(texts.contains(&"before:--foo"));
+        assert!(texts.contains(&"current:--b"));
+
+        // With an option before the proxy, the machine has two valid parses:
+        // 1. --verbose consumed as option → proxy sees ["my-script"]
+        // 2. --verbose consumed as proxy arg → proxy sees ["--verbose", "my-script"]
+        // Both parses contribute completions, so we see results from both.
+        let context = CompletionContext::new(vec!["run", "--verbose", "my-script"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"before:my-script"));
+        assert!(texts.contains(&"current:"));
+    }
+
+    #[test]
+    fn test_proxy_with_keyword_before() {
+        // Command: `run <keyword> <proxy...>`
+        // The proxy completer should only see its own args, not the keyword.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Positional(PositionalSpec::Keyword {
+                        expected: "scripts".to_string(),
+                    }),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(echo_context_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `run scripts <TAB>` — first proxy arg, completer should see no prior args
+        let context = CompletionContext::new(vec!["run", "scripts"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"current:"));
+        assert!(!texts.iter().any(|t| t.starts_with("before:")),
+            "keyword 'scripts' should not appear in proxy completer context, got: {:?}", texts);
+
+        // `run scripts hello world <TAB>` — third proxy arg
+        let context = CompletionContext::new(vec!["run", "scripts", "hello", "world"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"before:hello"));
+        assert!(texts.contains(&"before:world"));
+        assert!(!texts.iter().any(|t| *t == "before:scripts"),
+            "keyword should not leak into proxy context");
+    }
+
+    #[test]
+    fn test_proxy_without_completer() {
+        // A proxy without a completer should produce no completions at all.
+        // In particular, options from the command should not leak through.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: None,
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `run foo <TAB>` — proxy has started, no completer set
+        let context = CompletionContext::new(vec!["run", "foo"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(!texts.contains(&"--verbose"),
+            "options should not leak through proxy without completer");
+        // The only completions might come from the non-proxy parse path (where
+        // --verbose hasn't been consumed yet), but no positional completions.
+    }
+
+    #[test]
+    fn test_proxy_multiple_commands_no_bleed() {
+        // Two commands: `run <proxy...>` and `build <positional>`.
+        // Completing after `run foo` should not suggest `build`'s options.
+        fn run_completer(ctx: &CompletionContext) -> Vec<Completion> {
+            vec![Completion::new(format!("run-completion:{}", ctx.current))]
+        }
+
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(run_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["build".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--release")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "TARGET".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: Some(0),
+                        is_prefix: false,
+                        is_proxy: false,
+                        completer: Some(branch_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `run foo <TAB>` — should only get run's proxy completions
+        let context = CompletionContext::new(vec!["run", "foo"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"run-completion:"));
+        assert!(!texts.contains(&"--release"),
+            "build's options should not appear in run's proxy completions");
+        assert!(!texts.contains(&"main"),
+            "build's positional completions should not bleed into run");
+    }
+
+    #[test]
+    fn test_options_complete_before_proxy_starts() {
+        // `run --<TAB>` should still suggest --verbose since no proxy arg consumed yet
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                    Component::Option(OptionSpec::parametrized("--output")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(script_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `run --<TAB>` — no proxy arg yet, options should be suggested
+        let context = CompletionContext::new(vec!["run"], "--");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"--verbose"));
+        assert!(texts.contains(&"--output"));
+    }
+
+    #[test]
+    fn test_proxy_swallows_option_like_args() {
+        // Once proxy has consumed at least one arg, option-like args should go
+        // to the proxy completer rather than being treated as CLI options.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(echo_context_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `run test --some-flag --<TAB>` — proxy has started, option-like input
+        // should be passed to the proxy completer, not matched as CLI options.
+        let context = CompletionContext::new(vec!["run", "test", "--some-flag"], "--");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        // The echo completer should receive the option-like args as proxy context
+        assert!(texts.contains(&"before:test"));
+        assert!(texts.contains(&"before:--some-flag"));
+        assert!(texts.contains(&"current:--"));
+    }
+
+    #[test]
+    fn test_cross_binary_proxy_delegation() {
+        // Simulates binary A having a proxy that delegates completion to binary B.
+        //
+        // Binary B is a CLI with commands: `install`, `publish`, `test`
+        // Binary A has: `workspace run <proxy...>` where the proxy completer
+        // constructs binary B's CLI and calls compute_completions on it.
+
+        // This is Binary B's "CLI definition"
+        fn inner_cli_specs() -> Vec<CommandSpec> {
+            vec![
+                CommandSpec {
+                    primary_path: vec!["install".to_string()],
+                    components: vec![
+                        Component::Option(OptionSpec::boolean("--frozen")),
+                    ],
+                    ..Default::default()
+                },
+                CommandSpec {
+                    primary_path: vec!["publish".to_string()],
+                    components: vec![
+                        Component::Option(OptionSpec::boolean("--dry-run")),
+                        Component::Option(OptionSpec::parametrized("--tag")),
+                    ],
+                    ..Default::default()
+                },
+                CommandSpec {
+                    primary_path: vec!["test".to_string()],
+                    components: vec![
+                        Component::Option(OptionSpec::boolean("--watch")),
+                    ],
+                    ..Default::default()
+                },
+            ]
+        }
+
+        // Binary A's proxy completer: delegates to binary B's completion engine
+        fn delegate_completer(ctx: &CompletionContext) -> Vec<Completion> {
+            let specs = inner_cli_specs();
+            let mut builder = CliBuilder::new();
+            for spec in &specs {
+                builder.add_command(spec);
+            }
+            let machine = builder.compile();
+            let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+            // Forward the positional-local context directly to binary B's engine
+            let result = compute_completions(&command_refs, &machine, ctx);
+            result.completions
+        }
+
+        // Binary A's CLI:
+        //   - `workspace run <proxy...>` (delegates to binary B)
+        //   - `workspace list` (a non-proxy sibling command)
+        //   - `deploy <target>` (a top-level non-proxy command)
+        let outer_specs = vec![
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "ARGS".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(delegate_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "list".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--json")),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["deploy".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--force")),
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "TARGET".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: Some(0),
+                        is_prefix: false,
+                        is_proxy: false,
+                        completer: Some(branch_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &outer_specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let outer_refs: Vec<&CommandSpec> = outer_specs.iter().collect();
+
+        // `<TAB>` — top-level: should see all path keywords from binary A
+        let context = CompletionContext::new(vec![], "");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"workspace"), "got: {:?}", texts);
+        assert!(texts.contains(&"deploy"), "got: {:?}", texts);
+        // No inner CLI commands should leak to the top level
+        assert!(!texts.contains(&"install"));
+        assert!(!texts.contains(&"publish"));
+
+        // `workspace <TAB>` — should see both `run` and `list` subcommands
+        let context = CompletionContext::new(vec!["workspace"], "");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"run"), "got: {:?}", texts);
+        assert!(texts.contains(&"list"), "got: {:?}", texts);
+        assert!(!texts.contains(&"deploy"), "sibling top-level command should not appear here");
+
+        // `workspace run <TAB>` — should see binary B's commands merged with
+        // binary A's --verbose (proxy hasn't started yet)
+        let context = CompletionContext::new(vec!["workspace", "run"], "");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"install"), "inner CLI commands should appear, got: {:?}", texts);
+        assert!(texts.contains(&"publish"));
+        assert!(texts.contains(&"test"));
+        assert!(texts.contains(&"--verbose"), "outer option still valid before proxy starts");
+        // Sibling command options should NOT appear
+        assert!(!texts.contains(&"--json"), "workspace list's options should not appear here");
+        assert!(!texts.contains(&"--force"), "deploy's options should not appear here");
+        // Sibling completions from branch_completer should not appear
+        assert!(!texts.contains(&"main"));
+
+        // `workspace run t<TAB>` — should filter to inner commands starting with "t"
+        let context = CompletionContext::new(vec!["workspace", "run"], "t");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"test"));
+        assert!(!texts.contains(&"install"));
+        assert!(!texts.contains(&"publish"));
+
+        // `workspace run publish --<TAB>` — should see binary B's publish options
+        let context = CompletionContext::new(vec!["workspace", "run", "publish"], "--");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"--dry-run"), "should see inner command's options, got: {:?}", texts);
+        assert!(texts.contains(&"--tag"));
+        // publish's options, not install's or test's
+        assert!(!texts.contains(&"--frozen"));
+        assert!(!texts.contains(&"--watch"));
+        // Outer CLI options should not appear (proxy has started)
+        assert!(!texts.contains(&"--json"));
+        assert!(!texts.contains(&"--force"));
+
+        // `workspace run install --frozen <TAB>` — after using an inner option
+        let context = CompletionContext::new(vec!["workspace", "run", "install", "--frozen"], "");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        // --frozen already used and is single-use, should not be suggested again
+        assert!(!texts.contains(&"--frozen"),
+            "already-used inner option should be filtered, got: {:?}", texts);
+
+        // `workspace list --<TAB>` — sibling command should work independently
+        let context = CompletionContext::new(vec!["workspace", "list"], "--");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"--json"), "got: {:?}", texts);
+        // No proxy/inner CLI options should leak
+        assert!(!texts.contains(&"--verbose"));
+        assert!(!texts.contains(&"--frozen"));
+        assert!(!texts.contains(&"--dry-run"));
+
+        // `deploy <TAB>` — should see branch completions, not inner CLI commands
+        let context = CompletionContext::new(vec!["deploy"], "");
+        let result = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"main"), "deploy should see branch completions, got: {:?}", texts);
+        assert!(texts.contains(&"develop"));
+        assert!(!texts.contains(&"install"), "inner CLI should not leak into deploy");
+        assert!(!texts.contains(&"publish"));
     }
 }

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -74,7 +74,8 @@ impl<'a> CompletionContext<'a> {
         if args.is_empty() {
             Self::new(vec![], "")
         } else {
-            let last_arg = args[args.len() - 1];
+            let last_arg
+                = args[args.len() - 1];
             Self::new(args[..args.len() - 1].to_vec(), last_arg)
         }
     }
@@ -97,39 +98,45 @@ pub fn compute_completions<'cmds, 'args>(
     context: &CompletionContext<'args>,
 ) -> CompletionResult {
     // Run the machine with the arguments before the current token to get the current states
-    let states = run_machine_partial(machine, &context.args_before);
+    let states
+        = run_machine_partial(machine, &context.args_before);
 
     // Now analyze each state to find valid completions
     // Use a BTreeMap keyed by text so that entries with descriptions
     // take precedence over bare entries for the same keyword.
-    let mut completions: BTreeMap<String, Completion> = BTreeMap::new();
+    let mut completions: BTreeMap<String, Completion>
+        = BTreeMap::new();
 
     for state in &states {
         if state.node_id == ERROR_NODE_ID {
             continue;
         }
 
-        let node = &machine.nodes[state.node_id];
-        let command = commands.get(state.context_id);
+        let node
+            = &machine.nodes[state.node_id];
+        let command
+            = commands.get(state.context_id);
 
         // Build a set of already-used option component IDs
-        let used_option_ids: std::collections::HashSet<usize> = state
-            .option_values
-            .iter()
-            .map(|(id, _)| *id)
-            .collect();
+        let used_option_ids: std::collections::HashSet<usize>
+            = state.option_values.iter()
+                .map(|(id, _)| *id)
+                .collect();
 
         // Collect static transitions (command paths, keywords)
         for (key, _transitions) in &node.statics {
             if let ArgKey::User(keyword) = key {
                 // Check if the current partial matches
                 if keyword.starts_with(context.current) {
-                    let mut completion = Completion::new(*keyword).as_path();
+                    let mut completion
+                        = Completion::new(*keyword).as_path();
 
                     // If this keyword is the last segment of the command's path,
                     // attach the command's description.
                     if let Some(cmd) = command {
-                        let idx = state.keyword_count;
+                        let idx
+                            = state.keyword_count;
+
                         let is_last_segment = |path: &[String]| {
                             idx + 1 == path.len()
                                 && path.get(idx).map_or(false, |s| s.as_str() == *keyword)
@@ -151,16 +158,18 @@ pub fn compute_completions<'cmds, 'args>(
 
         // Collect dynamic transitions (options and positionals)
         // Only suggest if this specific state's command has a complete path
-        let state_has_complete_path = if let Some(cmd) = command {
-            state.keyword_count >= cmd.primary_path.len()
-        } else {
-            false
-        };
+        let state_has_complete_path
+            = if let Some(cmd) = command {
+                state.keyword_count >= cmd.primary_path.len()
+            } else {
+                false
+            };
 
         if state_has_complete_path {
             // Collect matching option completions for this state first, then
             // only include undescribed options when no described option matches.
-            let mut option_candidates: Vec<Completion> = Vec::new();
+            let mut option_candidates: Vec<Completion>
+                = Vec::new();
 
             for (check, _) in &node.dynamics {
                 if let Some(Check::IsOption(name)) = check {
@@ -178,12 +187,16 @@ pub fn compute_completions<'cmds, 'args>(
                     if name.starts_with(context.current) {
                         if let Some(cmd) = command {
                             if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
-                                let is_single_use = opt.extra_len.is_some();
+                                let is_single_use
+                                    = opt.extra_len.is_some();
+
                                 if is_single_use && used_option_ids.contains(&component_id) {
                                     continue;
                                 }
 
-                                let mut completion = Completion::new(*name).as_option();
+                                let mut completion
+                                    = Completion::new(*name).as_option();
+
                                 if let Some(doc) = &opt.documentation {
                                     completion = completion.with_description(doc.description.clone());
                                 }
@@ -196,7 +209,9 @@ pub fn compute_completions<'cmds, 'args>(
                 }
             }
 
-            let has_any_described = option_candidates.iter().any(|c| c.description.is_some());
+            let has_any_described
+                = option_candidates.iter().any(|c| c.description.is_some());
+
             for c in option_candidates {
                 if !has_any_described || c.description.is_some() {
                     insert_completion(&mut completions, c);
@@ -208,24 +223,27 @@ pub fn compute_completions<'cmds, 'args>(
                     Some(Check::IsNotOptionLike) | None => {
                         // Positional argument — invoke completer if available
                         if let Some(cmd) = command {
-                            let component_id = match &transition.reducer {
-                                Some(Reducer::StartValue(Attachment::Positional, id)) => Some(*id),
-                                Some(Reducer::PushValue(Attachment::Positional)) => {
-                                    state.positional_values.last().map(|(id, _)| *id)
-                                }
-                                _ => None,
-                            };
+                            let component_id
+                                = match &transition.reducer {
+                                    Some(Reducer::StartValue(Attachment::Positional, id)) => Some(*id),
+                                    Some(Reducer::PushValue(Attachment::Positional)) => {
+                                        state.positional_values.last().map(|(id, _)| *id)
+                                    }
+                                    _ => None,
+                                };
 
                             if let Some(id) = component_id {
                                 if let Some(Component::Positional(PositionalSpec::Dynamic { completer: Some(f), .. })) = cmd.components.get(id) {
                                     // Build a context local to this positional: only include
                                     // values already consumed by this specific component.
-                                    let positional_args: Vec<&str> = state.positional_values.iter()
-                                        .filter(|(cid, _)| *cid == id)
-                                        .flat_map(|(_, values)| values.iter().map(|v| v.value))
-                                        .collect();
+                                    let positional_args: Vec<&str>
+                                        = state.positional_values.iter()
+                                            .filter(|(cid, _)| *cid == id)
+                                            .flat_map(|(_, values)| values.iter().map(|v| v.value))
+                                            .collect();
 
-                                    let local_context = CompletionContext::new(positional_args, context.current);
+                                    let local_context
+                                        = CompletionContext::new(positional_args, context.current);
 
                                     for c in f(&local_context) {
                                         insert_completion(&mut completions, c);
@@ -315,7 +333,8 @@ impl Shell {
         std::env::var("SHELL")
             .ok()
             .and_then(|s| {
-                let shell_name = s.rsplit('/').next()?;
+                let shell_name
+                    = s.rsplit('/').next()?;
                 Self::from_str(shell_name)
             })
     }
@@ -324,9 +343,11 @@ impl Shell {
 /// Returns the environment variable name used to signal that completions are enabled.
 /// Derived from the binary name (e.g. `my-cli` → `_MY_CLI_COMPLETIONS`).
 pub fn completion_env_var(binary_name: &str) -> String {
-    let sanitized: String = binary_name.chars()
-        .map(|c| if c.is_alphanumeric() { c.to_ascii_uppercase() } else { '_' })
-        .collect();
+    let sanitized: String
+        = binary_name.chars()
+            .map(|c| if c.is_alphanumeric() { c.to_ascii_uppercase() } else { '_' })
+            .collect();
+
     format!("_{}_COMPLETIONS", sanitized)
 }
 
@@ -337,15 +358,17 @@ pub fn is_completion_enabled(binary_name: &str) -> bool {
 
 fn generate_bash_script(command: &str) -> String {
     // Extract the binary name from the command (last path component, no arguments)
-    let binary_name = command
-        .split_whitespace()
-        .next()
-        .unwrap_or(command)
-        .rsplit('/')
-        .next()
-        .unwrap_or(command);
+    let binary_name
+        = command
+            .split_whitespace()
+            .next()
+            .unwrap_or(command)
+            .rsplit('/')
+            .next()
+            .unwrap_or(command);
 
-    let env_var = completion_env_var(binary_name);
+    let env_var
+        = completion_env_var(binary_name);
 
     format!(
         r#"# Bash completion script for {binary_name}
@@ -381,17 +404,20 @@ complete -F _{binary_name}_completions {binary_name}
 }
 
 fn generate_zsh_script(command: &str) -> String {
-    let binary_name = command
-        .split_whitespace()
-        .next()
-        .unwrap_or(command)
-        .rsplit('/')
-        .next()
-        .unwrap_or(command);
+    let binary_name
+        = command
+            .split_whitespace()
+            .next()
+            .unwrap_or(command)
+            .rsplit('/')
+            .next()
+            .unwrap_or(command);
 
     // Replace hyphens with underscores for valid zsh function name
-    let func_name = binary_name.replace('-', "_");
-    let env_var = completion_env_var(binary_name);
+    let func_name
+        = binary_name.replace('-', "_");
+    let env_var
+        = completion_env_var(binary_name);
 
     format!(
         r#"# Zsh completion script for {binary_name}
@@ -434,15 +460,17 @@ compdef _{func_name} {binary_name}
 }
 
 fn generate_fish_script(command: &str) -> String {
-    let binary_name = command
-        .split_whitespace()
-        .next()
-        .unwrap_or(command)
-        .rsplit('/')
-        .next()
-        .unwrap_or(command);
+    let binary_name
+        = command
+            .split_whitespace()
+            .next()
+            .unwrap_or(command)
+            .rsplit('/')
+            .next()
+            .unwrap_or(command);
 
-    let env_var = completion_env_var(binary_name);
+    let env_var
+        = completion_env_var(binary_name);
 
     format!(
         r#"# Fish completion script for {binary_name}
@@ -515,19 +543,30 @@ mod tests {
 
     #[test]
     fn test_complete_empty_input() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec![], "");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+        let context
+            = CompletionContext::new(vec![], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
 
         // Should suggest command paths
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"add"));
         assert!(texts.contains(&"commit"));
         assert!(texts.contains(&"checkout"));
@@ -535,19 +574,30 @@ mod tests {
 
     #[test]
     fn test_complete_partial_command() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec![], "co");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+        let context
+            = CompletionContext::new(vec![], "co");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
 
         // Should only suggest commands starting with "co" (commit, not checkout which starts with "ch")
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"commit"));
         assert!(!texts.contains(&"checkout")); // checkout starts with "ch", not "co"
         assert!(!texts.contains(&"add"));
@@ -555,19 +605,30 @@ mod tests {
 
     #[test]
     fn test_complete_options_after_command() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec!["add"], "-");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+        let context
+            = CompletionContext::new(vec!["add"], "-");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
 
         // Should suggest long options for 'add' command (short options are filtered out)
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(!texts.contains(&"-v")); // Short options filtered out
         assert!(texts.contains(&"--verbose"));
         assert!(!texts.contains(&"-m")); // Short options filtered out
@@ -576,58 +637,91 @@ mod tests {
 
     #[test]
     fn test_complete_long_option_prefix() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec!["add"], "--v");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+        let context
+            = CompletionContext::new(vec!["add"], "--v");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
 
         // Should only suggest --verbose
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"--verbose"));
         assert!(!texts.contains(&"--message"));
     }
 
     #[test]
     fn test_complete_from_args_at_end() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::from_args_at_end(vec!["add", "--"]);
-        let result = compute_completions(&command_refs, &machine, &context);
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+        let context
+            = CompletionContext::from_args_at_end(vec!["add", "--"]);
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
 
         // Should suggest long options
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"--verbose"));
         assert!(texts.contains(&"--message"));
     }
 
     #[test]
     fn test_filter_already_used_options() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // After using --verbose, it should not be suggested again
-        let context = CompletionContext::new(vec!["add", "--verbose"], "-");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let context
+            = CompletionContext::new(vec!["add", "--verbose"], "-");
 
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(!texts.contains(&"--verbose")); // Should be filtered out (already used)
         assert!(!texts.contains(&"-v")); // Short options are filtered out
         assert!(!texts.contains(&"-m")); // Short options are filtered out
@@ -636,21 +730,32 @@ mod tests {
 
     #[test]
     fn test_no_options_when_path_incomplete() {
-        let specs = create_simple_cli();
-        let mut builder = CliBuilder::new();
+        let specs
+            = create_simple_cli();
+
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // When no command has been typed yet, options should not be suggested
         // even if the current token looks like an option
-        let context = CompletionContext::new(vec![], "-");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let context
+            = CompletionContext::new(vec![], "-");
 
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         // Should only have command paths, no options
         assert!(!texts.contains(&"-v"));
         assert!(!texts.contains(&"--verbose"));
@@ -687,30 +792,52 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // Top-level: single-segment commands get their description
-        let context = CompletionContext::new(vec![], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let add = result.completions.iter().find(|c| c.text == "add").unwrap();
+        let context
+            = CompletionContext::new(vec![], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let add
+            = result.completions.iter().find(|c| c.text == "add").unwrap();
         assert_eq!(add.description.as_deref(), Some("Add files to staging"));
-        let commit = result.completions.iter().find(|c| c.text == "commit").unwrap();
+
+        let commit
+            = result.completions.iter().find(|c| c.text == "commit").unwrap();
         assert_eq!(commit.description.as_deref(), Some("Record changes"));
+
         // "workspace" is not a final segment, so no description
-        let workspace = result.completions.iter().find(|c| c.text == "workspace").unwrap();
+        let workspace
+            = result.completions.iter().find(|c| c.text == "workspace").unwrap();
         assert_eq!(workspace.description, None);
 
         // After "workspace": "run" and "list" are final segments and get descriptions
-        let context = CompletionContext::new(vec!["workspace"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let run = result.completions.iter().find(|c| c.text == "run").unwrap();
+        let context
+            = CompletionContext::new(vec!["workspace"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let run
+            = result.completions.iter().find(|c| c.text == "run").unwrap();
         assert_eq!(run.description.as_deref(), Some("Run a workspace script"));
-        let list = result.completions.iter().find(|c| c.text == "list").unwrap();
+
+        let list
+            = result.completions.iter().find(|c| c.text == "list").unwrap();
         assert_eq!(list.description.as_deref(), Some("List workspaces"));
     }
 
@@ -737,25 +864,39 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `workspace --<TAB>` — only "workspace" command's path is complete
-        let context = CompletionContext::new(vec!["workspace"], "--");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
 
         assert!(texts.contains(&"--json"), "complete command's options should appear, got: {:?}", texts);
         assert!(!texts.contains(&"--verbose"), "incomplete path command's options should NOT appear, got: {:?}", texts);
 
         // `workspace run --<TAB>` — now both paths are complete
-        let context = CompletionContext::new(vec!["workspace", "run"], "--");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "run"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
 
         assert!(texts.contains(&"--verbose"), "after full path, options should appear, got: {:?}", texts);
     }
@@ -771,7 +912,8 @@ mod tests {
 
     #[test]
     fn test_bash_script_generation() {
-        let script = generate_completion_script(Shell::Bash, "my-cli");
+        let script
+            = generate_completion_script(Shell::Bash, "my-cli");
         assert!(script.contains("complete -F _my-cli_completions my-cli"));
         assert!(script.contains("--clipanion-complete"));
         assert!(script.contains("-- \"${words[@]:1}\"")); // Uses -- separator
@@ -779,7 +921,8 @@ mod tests {
 
     #[test]
     fn test_zsh_script_generation() {
-        let script = generate_completion_script(Shell::Zsh, "my-cli");
+        let script
+            = generate_completion_script(Shell::Zsh, "my-cli");
         assert!(script.contains("compdef _my_cli my-cli")); // Function name has underscores
         assert!(script.contains("--clipanion-complete"));
         assert!(script.contains("-- \"${words[@]:1}\"")); // Uses -- separator
@@ -788,7 +931,8 @@ mod tests {
 
     #[test]
     fn test_fish_script_generation() {
-        let script = generate_completion_script(Shell::Fish, "my-cli");
+        let script
+            = generate_completion_script(Shell::Fish, "my-cli");
         assert!(script.contains("complete -c my-cli"));
         assert!(script.contains("--clipanion-complete"));
         assert!(script.contains("-- $tokens")); // Uses -- separator
@@ -796,13 +940,16 @@ mod tests {
 
     #[test]
     fn test_script_with_path_command() {
-        let script = generate_completion_script(Shell::Bash, "/usr/local/bin/my-cli");
+        let script
+            = generate_completion_script(Shell::Bash, "/usr/local/bin/my-cli");
         // Should extract binary name from path
         assert!(script.contains("complete -F _my-cli_completions my-cli"));
     }
 
     fn branch_completer(ctx: &CompletionContext) -> Vec<Completion> {
-        let branches = vec!["main", "develop", "feature/login", "feature/search"];
+        let branches
+            = vec!["main", "develop", "feature/login", "feature/search"];
+
         branches.into_iter()
             .filter(|b| b.starts_with(ctx.current))
             .map(|b| Completion::new(b))
@@ -829,27 +976,40 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // Complete with empty input after "checkout"
-        let context = CompletionContext::new(vec!["checkout"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["checkout"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"main"));
         assert!(texts.contains(&"develop"));
         assert!(texts.contains(&"feature/login"));
         assert!(texts.contains(&"feature/search"));
 
         // Complete with partial input
-        let context = CompletionContext::new(vec!["checkout"], "fe");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["checkout"], "fe");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(!texts.contains(&"main"));
         assert!(!texts.contains(&"develop"));
         assert!(texts.contains(&"feature/login"));
@@ -877,21 +1037,32 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let machine
+            = builder.compile();
 
-        let context = CompletionContext::new(vec!["checkout"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+
+        let context
+            = CompletionContext::new(vec!["checkout"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
         assert!(result.completions.is_empty());
     }
 
     fn script_completer(ctx: &CompletionContext) -> Vec<Completion> {
-        let scripts = vec!["build", "test", "lint", "start"];
+        let scripts
+            = vec!["build", "test", "lint", "start"];
+
         scripts.into_iter()
             .filter(|s| s.starts_with(ctx.current))
             .map(|s| Completion::new(s))
@@ -920,34 +1091,51 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
 
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // Complete first proxy arg
-        let context = CompletionContext::new(vec!["run"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"build"));
         assert!(texts.contains(&"test"));
         assert!(texts.contains(&"lint"));
         assert!(texts.contains(&"start"));
 
         // Complete with partial input
-        let context = CompletionContext::new(vec!["run"], "t");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run"], "t");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"test"));
         assert!(!texts.contains(&"build"));
 
         // Complete subsequent proxy arg (should still invoke completer via PushValue)
-        let context = CompletionContext::new(vec!["run", "test"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "test"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"build"));
         assert!(texts.contains(&"test"));
     }
@@ -956,10 +1144,13 @@ mod tests {
     /// that the engine slices the context correctly for proxy positionals.
     fn echo_context_completer(ctx: &CompletionContext) -> Vec<Completion> {
         // Return each prior arg as a completion, plus "current:<current>" to verify
-        let mut result: Vec<Completion> = ctx.args_before.iter()
-            .map(|a| Completion::new(format!("before:{}", a)))
-            .collect();
+        let mut result: Vec<Completion>
+            = ctx.args_before.iter()
+                .map(|a| Completion::new(format!("before:{}", a)))
+                .collect();
+
         result.push(Completion::new(format!("current:{}", ctx.current)));
+
         result
     }
 
@@ -984,34 +1175,52 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // First proxy arg: completer should see no prior args
         // Full command: `run <TAB>` → args_before for completer = []
-        let context = CompletionContext::new(vec!["run"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"current:"));
         assert!(!texts.iter().any(|t| t.starts_with("before:")));
 
         // Second proxy arg: completer should see only the first proxy arg
         // Full command: `run my-script <TAB>` → args_before for completer = ["my-script"]
-        let context = CompletionContext::new(vec!["run", "my-script"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "my-script"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"before:my-script"));
         assert!(texts.contains(&"current:"));
 
         // Third proxy arg with partial: completer should see two prior proxy args
         // Full command: `run my-script --foo --b` → args_before for completer = ["my-script", "--foo"]
-        let context = CompletionContext::new(vec!["run", "my-script", "--foo"], "--b");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "my-script", "--foo"], "--b");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"before:my-script"));
         assert!(texts.contains(&"before:--foo"));
         assert!(texts.contains(&"current:--b"));
@@ -1020,9 +1229,13 @@ mod tests {
         // 1. --verbose consumed as option → proxy sees ["my-script"]
         // 2. --verbose consumed as proxy arg → proxy sees ["--verbose", "my-script"]
         // Both parses contribute completions, so we see results from both.
-        let context = CompletionContext::new(vec!["run", "--verbose", "my-script"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "--verbose", "my-script"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"before:my-script"));
         assert!(texts.contains(&"current:"));
     }
@@ -1052,25 +1265,39 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `run scripts <TAB>` — first proxy arg, completer should see no prior args
-        let context = CompletionContext::new(vec!["run", "scripts"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "scripts"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"current:"));
         assert!(!texts.iter().any(|t| t.starts_with("before:")),
             "keyword 'scripts' should not appear in proxy completer context, got: {:?}", texts);
 
         // `run scripts hello world <TAB>` — third proxy arg
-        let context = CompletionContext::new(vec!["run", "scripts", "hello", "world"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "scripts", "hello", "world"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"before:hello"));
         assert!(texts.contains(&"before:world"));
         assert!(!texts.iter().any(|t| *t == "before:scripts"),
@@ -1100,17 +1327,27 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `run foo <TAB>` — proxy has started, no completer set
-        let context = CompletionContext::new(vec!["run", "foo"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "foo"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(!texts.contains(&"--verbose"),
             "options should not leak through proxy without completer");
         // The only completions might come from the non-proxy parse path (where
@@ -1159,17 +1396,27 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `run foo <TAB>` — should only get run's proxy completions
-        let context = CompletionContext::new(vec!["run", "foo"], "");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "foo"], "");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"run-completion:"));
         assert!(!texts.contains(&"--release"),
             "build's options should not appear in run's proxy completions");
@@ -1200,17 +1447,27 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `run --<TAB>` — no proxy arg yet, options should be suggested
-        let context = CompletionContext::new(vec!["run"], "--");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"--verbose"));
         assert!(texts.contains(&"--output"));
     }
@@ -1238,18 +1495,28 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
 
         // `run test --some-flag --<TAB>` — proxy has started, option-like input
         // should be passed to the proxy completer, not matched as CLI options.
-        let context = CompletionContext::new(vec!["run", "test", "--some-flag"], "--");
-        let result = compute_completions(&command_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["run", "test", "--some-flag"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         // The echo completer should receive the option-like args as proxy context
         assert!(texts.contains(&"before:test"));
         assert!(texts.contains(&"before:--some-flag"));
@@ -1294,16 +1561,26 @@ mod tests {
 
         // Binary A's proxy completer: delegates to binary B's completion engine
         fn delegate_completer(ctx: &CompletionContext) -> Vec<Completion> {
-            let specs = inner_cli_specs();
-            let mut builder = CliBuilder::new();
+            let specs
+                = inner_cli_specs();
+
+            let mut builder
+                = CliBuilder::new();
+
             for spec in &specs {
                 builder.add_command(spec);
             }
-            let machine = builder.compile();
-            let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+            let machine
+                = builder.compile();
+
+            let command_refs: Vec<&CommandSpec>
+                = specs.iter().collect();
 
             // Forward the positional-local context directly to binary B's engine
-            let result = compute_completions(&command_refs, &machine, ctx);
+            let result
+                = compute_completions(&command_refs, &machine, ctx);
+
             result.completions
         }
 
@@ -1353,17 +1630,27 @@ mod tests {
             },
         ];
 
-        let mut builder = CliBuilder::new();
+        let mut builder
+            = CliBuilder::new();
+
         for spec in &outer_specs {
             builder.add_command(spec);
         }
-        let machine = builder.compile();
-        let outer_refs: Vec<&CommandSpec> = outer_specs.iter().collect();
+
+        let machine
+            = builder.compile();
+
+        let outer_refs: Vec<&CommandSpec>
+            = outer_specs.iter().collect();
 
         // `<TAB>` — top-level: should see all path keywords from binary A
-        let context = CompletionContext::new(vec![], "");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec![], "");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"workspace"), "got: {:?}", texts);
         assert!(texts.contains(&"deploy"), "got: {:?}", texts);
         // No inner CLI commands should leak to the top level
@@ -1371,18 +1658,26 @@ mod tests {
         assert!(!texts.contains(&"publish"));
 
         // `workspace <TAB>` — should see both `run` and `list` subcommands
-        let context = CompletionContext::new(vec!["workspace"], "");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace"], "");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"run"), "got: {:?}", texts);
         assert!(texts.contains(&"list"), "got: {:?}", texts);
         assert!(!texts.contains(&"deploy"), "sibling top-level command should not appear here");
 
         // `workspace run <TAB>` — should see binary B's commands merged with
         // binary A's --verbose (proxy hasn't started yet)
-        let context = CompletionContext::new(vec!["workspace", "run"], "");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "run"], "");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"install"), "inner CLI commands should appear, got: {:?}", texts);
         assert!(texts.contains(&"publish"));
         assert!(texts.contains(&"test"));
@@ -1394,17 +1689,25 @@ mod tests {
         assert!(!texts.contains(&"main"));
 
         // `workspace run t<TAB>` — should filter to inner commands starting with "t"
-        let context = CompletionContext::new(vec!["workspace", "run"], "t");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "run"], "t");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"test"));
         assert!(!texts.contains(&"install"));
         assert!(!texts.contains(&"publish"));
 
         // `workspace run publish --<TAB>` — should see binary B's publish options
-        let context = CompletionContext::new(vec!["workspace", "run", "publish"], "--");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "run", "publish"], "--");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"--dry-run"), "should see inner command's options, got: {:?}", texts);
         assert!(texts.contains(&"--tag"));
         // publish's options, not install's or test's
@@ -1415,17 +1718,25 @@ mod tests {
         assert!(!texts.contains(&"--force"));
 
         // `workspace run install --frozen <TAB>` — after using an inner option
-        let context = CompletionContext::new(vec!["workspace", "run", "install", "--frozen"], "");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "run", "install", "--frozen"], "");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         // --frozen already used and is single-use, should not be suggested again
         assert!(!texts.contains(&"--frozen"),
             "already-used inner option should be filtered, got: {:?}", texts);
 
         // `workspace list --<TAB>` — sibling command should work independently
-        let context = CompletionContext::new(vec!["workspace", "list"], "--");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["workspace", "list"], "--");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"--json"), "got: {:?}", texts);
         // No proxy/inner CLI options should leak
         assert!(!texts.contains(&"--verbose"));
@@ -1433,9 +1744,13 @@ mod tests {
         assert!(!texts.contains(&"--dry-run"));
 
         // `deploy <TAB>` — should see branch completions, not inner CLI commands
-        let context = CompletionContext::new(vec!["deploy"], "");
-        let result = compute_completions(&outer_refs, &machine, &context);
-        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        let context
+            = CompletionContext::new(vec!["deploy"], "");
+
+        let result
+            = compute_completions(&outer_refs, &machine, &context);
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
         assert!(texts.contains(&"main"), "deploy should see branch completions, got: {:?}", texts);
         assert!(texts.contains(&"develop"));
         assert!(!texts.contains(&"install"), "inner CLI should not leak into deploy");

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::{
-    builder::{Check, CommandSpec, Component, OptionSpec, Reducer, State},
+    builder::{Attachment, Check, CommandSpec, Component, OptionSpec, PositionalSpec, Reducer, State},
     runner::{Runner, RunnerState},
     shared::{Arg, ArgKey, ERROR_NODE_ID},
     Machine,
@@ -59,31 +59,23 @@ pub struct CompletionContext<'a> {
 
     /// The partial token being completed (empty if cursor is between tokens)
     pub current: &'a str,
-
-    /// Arguments after the current token
-    pub args_after: Vec<&'a str>,
-
-    /// Position of cursor within the current token (0 = beginning)
-    pub cursor_position: usize,
 }
 
 impl<'a> CompletionContext<'a> {
-    pub fn new(args_before: Vec<&'a str>, current: &'a str, args_after: Vec<&'a str>, cursor_position: usize) -> Self {
+    pub fn new(args_before: Vec<&'a str>, current: &'a str) -> Self {
         Self {
             args_before,
             current,
-            args_after,
-            cursor_position,
         }
     }
 
     /// Create a context from a full command line where the cursor is at the end
     pub fn from_args_at_end(args: Vec<&'a str>) -> Self {
         if args.is_empty() {
-            Self::new(vec![], "", vec![], 0)
+            Self::new(vec![], "")
         } else {
             let last_arg = args[args.len() - 1];
-            Self::new(args[..args.len() - 1].to_vec(), last_arg, vec![], last_arg.len())
+            Self::new(args[..args.len() - 1].to_vec(), last_arg)
         }
     }
 }
@@ -106,6 +98,18 @@ pub fn compute_completions<'cmds, 'args>(
 ) -> CompletionResult {
     // Run the machine with the arguments before the current token to get the current states
     let states = run_machine_partial(machine, &context.args_before);
+
+    // Check if any state has a complete path (has reached a command)
+    let has_complete_path = states.iter().any(|state| {
+        if state.node_id == ERROR_NODE_ID {
+            return false;
+        }
+        if let Some(cmd) = commands.get(state.context_id) {
+            state.keyword_count >= cmd.primary_path.len()
+        } else {
+            false
+        }
+    });
 
     // Now analyze each state to find valid completions
     let mut completions = BTreeSet::new();
@@ -135,47 +139,75 @@ pub fn compute_completions<'cmds, 'args>(
             }
         }
 
-        // Collect dynamic transitions (options)
-        for (check, _transition) in &node.dynamics {
-            if let Some(Check::IsOption(name)) = check {
-                // Don't suggest -- or -h/--help which are special
-                if *name == "--" || *name == "-h" || *name == "--help" {
-                    continue;
-                }
-
-                // Check if the current partial matches
-                if name.starts_with(context.current) {
-                    // Find the option spec to check if it's already used
-                    if let Some(cmd) = command {
-                        if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
-                            // Skip options that are already used and don't accept multiple values
-                            let is_single_use = opt.min_len == 0 && opt.extra_len == Some(0);
-                            if is_single_use && used_option_ids.contains(&component_id) {
-                                continue;
-                            }
-
-                            let description = opt.documentation.as_ref()
-                                .map(|doc| doc.description.clone());
-
-                            let mut completion = Completion::new(*name).as_option();
-                            if let Some(desc) = description {
-                                completion = completion.with_description(desc);
-                            }
-                            completions.insert(completion);
+        // Collect dynamic transitions (options and positionals)
+        // Only suggest if at least one state has a complete path (reached a command)
+        if has_complete_path {
+            for (check, transition) in &node.dynamics {
+                match check {
+                    Some(Check::IsOption(name)) => {
+                        // Don't suggest -- or -h/--help which are special
+                        if *name == "--" || *name == "-h" || *name == "--help" {
+                            continue;
                         }
-                    } else {
-                        // No command context, just add the option
-                        completions.insert(Completion::new(*name).as_option());
+
+                        // Only suggest long options (--foo), not short options (-f)
+                        if !name.starts_with("--") {
+                            continue;
+                        }
+
+                        // Check if the current partial matches
+                        if name.starts_with(context.current) {
+                            // Find the option spec to check if it's already used
+                            if let Some(cmd) = command {
+                                if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
+                                    // Skip options that are already used and don't accept multiple values
+                                    let is_single_use = opt.extra_len.is_some();
+                                    if is_single_use && used_option_ids.contains(&component_id) {
+                                        continue;
+                                    }
+
+                                    let description = opt.documentation.as_ref()
+                                        .map(|doc| doc.description.clone());
+
+                                    let mut completion = Completion::new(*name).as_option();
+                                    if let Some(desc) = description {
+                                        completion = completion.with_description(desc);
+                                    }
+                                    completions.insert(completion);
+                                }
+                            } else {
+                                // No command context, just add the option
+                                completions.insert(Completion::new(*name).as_option());
+                            }
+                        }
                     }
+
+                    Some(Check::IsNotOptionLike) | None => {
+                        // Positional argument — invoke completer if available
+                        if let Some(cmd) = command {
+                            let component_id = match &transition.reducer {
+                                Some(Reducer::StartValue(Attachment::Positional, id)) => Some(*id),
+                                Some(Reducer::PushValue(Attachment::Positional)) => {
+                                    state.positional_values.last().map(|(id, _)| *id)
+                                }
+                                _ => None,
+                            };
+
+                            if let Some(id) = component_id {
+                                if let Some(Component::Positional(PositionalSpec::Dynamic { completer: Some(f), .. })) = cmd.components.get(id) {
+                                    for c in f(context.current) {
+                                        completions.insert(c);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    _ => {}
                 }
             }
         }
 
-        // If current starts with -, filter to only options
-        if !context.current.is_empty() && context.current.starts_with("-") && !state.post_double_dash {
-            // Only show options
-            completions.retain(|c| c.is_option);
-        }
     }
 
     CompletionResult {
@@ -243,6 +275,20 @@ impl Shell {
     }
 }
 
+/// Returns the environment variable name used to signal that completions are enabled.
+/// Derived from the binary name (e.g. `my-cli` → `_MY_CLI_COMPLETIONS`).
+pub fn completion_env_var(binary_name: &str) -> String {
+    let sanitized: String = binary_name.chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_uppercase() } else { '_' })
+        .collect();
+    format!("_{}_COMPLETIONS", sanitized)
+}
+
+/// Returns `true` if the completion script has been sourced in the current shell session.
+pub fn is_completion_enabled(binary_name: &str) -> bool {
+    std::env::var(completion_env_var(binary_name)).is_ok()
+}
+
 fn generate_bash_script(command: &str) -> String {
     // Extract the binary name from the command (last path component, no arguments)
     let binary_name = command
@@ -253,10 +299,14 @@ fn generate_bash_script(command: &str) -> String {
         .next()
         .unwrap_or(command);
 
+    let env_var = completion_env_var(binary_name);
+
     format!(
         r#"# Bash completion script for {binary_name}
 # Generated by clipanion-rs
 # Add this to your ~/.bashrc or source it directly
+
+export {env_var}=1
 
 _{binary_name}_completions() {{
     local cur prev words cword
@@ -269,13 +319,17 @@ _{binary_name}_completions() {{
     completions=$({command} --clipanion-complete "$index" -- "${{words[@]:1}}" 2>/dev/null)
 
     if [[ -n "$completions" ]]; then
-        COMPREPLY=($(compgen -W "$completions" -- "$cur"))
+        # Strip descriptions (tab-separated) since bash doesn't support them
+        local words_only
+        words_only=$(echo "$completions" | cut -f1)
+        COMPREPLY=($(compgen -W "$words_only" -- "$cur"))
     fi
 }}
 
 complete -F _{binary_name}_completions {binary_name}
 "#,
         binary_name = binary_name,
+        env_var = env_var,
         command = command,
     )
 }
@@ -291,11 +345,14 @@ fn generate_zsh_script(command: &str) -> String {
 
     // Replace hyphens with underscores for valid zsh function name
     let func_name = binary_name.replace('-', "_");
+    let env_var = completion_env_var(binary_name);
 
     format!(
         r#"# Zsh completion script for {binary_name}
 # Generated by clipanion-rs
 # Add this to your ~/.zshrc or place in a file in your $fpath
+
+export {env_var}=1
 
 _{func_name}() {{
     local -a completions
@@ -304,20 +361,27 @@ _{func_name}() {{
     # CURRENT is 1-based and includes command name, convert to 0-based index without command
     local index=$((CURRENT - 2))
 
-    # Get completions from the CLI
+    # Get completions from the CLI (format: text or text\tdescription)
     while IFS= read -r line; do
-        completions+=("$line")
+        if [[ "$line" == *$'\t'* ]]; then
+            local text="${{line%%$'\t'*}}"
+            local desc="${{line#*$'\t'}}"
+            completions+=("${{text}}:${{desc}}")
+        else
+            completions+=("$line")
+        fi
     done < <({command} --clipanion-complete "$index" -- "${{words[@]:1}}" 2>/dev/null)
 
-    # Add completions
+    # Add completions with descriptions
     if (( $#completions )); then
-        compadd -a completions
+        _describe 'completion' completions
     fi
 }}
 
 compdef _{func_name} {binary_name}
 "#,
         binary_name = binary_name,
+        env_var = env_var,
         func_name = func_name,
         command = command,
     )
@@ -332,10 +396,14 @@ fn generate_fish_script(command: &str) -> String {
         .next()
         .unwrap_or(command);
 
+    let env_var = completion_env_var(binary_name);
+
     format!(
         r#"# Fish completion script for {binary_name}
 # Generated by clipanion-rs
 # Save this file to ~/.config/fish/completions/{binary_name}.fish
+
+set -gx {env_var} 1
 
 function __fish_{binary_name}_completions
     set -l tokens (commandline -opc)
@@ -344,12 +412,13 @@ function __fish_{binary_name}_completions
     # Remove the command name itself (first token)
     set -e tokens[1]
 
-    # Count tokens to get the index (current token position)
+    # commandline -opc already includes the partial token at cursor,
+    # so don't append commandline -ct again.
+    # When current is empty, cursor is after a space (new argument position).
+    # When current is non-empty, it's the last element of tokens.
     set -l index (count $tokens)
-
-    # Add the current token to the args if it's not empty
     if test -n "$current"
-        set tokens $tokens "$current"
+        set index (math $index - 1)
     end
 
     {command} --clipanion-complete "$index" -- $tokens 2>/dev/null
@@ -358,6 +427,7 @@ end
 complete -c {binary_name} -f -a '(__fish_{binary_name}_completions)'
 "#,
         binary_name = binary_name,
+        env_var = env_var,
         command = command,
     )
 }
@@ -407,7 +477,7 @@ mod tests {
         let machine = builder.compile();
 
         let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec![], "", vec![], 0);
+        let context = CompletionContext::new(vec![], "");
         let result = compute_completions(&command_refs, &machine, &context);
 
         // Should suggest command paths
@@ -427,7 +497,7 @@ mod tests {
         let machine = builder.compile();
 
         let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec![], "co", vec![], 2);
+        let context = CompletionContext::new(vec![], "co");
         let result = compute_completions(&command_refs, &machine, &context);
 
         // Should only suggest commands starting with "co" (commit, not checkout which starts with "ch")
@@ -447,14 +517,14 @@ mod tests {
         let machine = builder.compile();
 
         let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec!["add"], "-", vec![], 1);
+        let context = CompletionContext::new(vec!["add"], "-");
         let result = compute_completions(&command_refs, &machine, &context);
 
-        // Should suggest options for 'add' command
+        // Should suggest long options for 'add' command (short options are filtered out)
         let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
-        assert!(texts.contains(&"-v"));
+        assert!(!texts.contains(&"-v")); // Short options filtered out
         assert!(texts.contains(&"--verbose"));
-        assert!(texts.contains(&"-m"));
+        assert!(!texts.contains(&"-m")); // Short options filtered out
         assert!(texts.contains(&"--message"));
     }
 
@@ -468,7 +538,7 @@ mod tests {
         let machine = builder.compile();
 
         let command_refs: Vec<&CommandSpec> = specs.iter().collect();
-        let context = CompletionContext::new(vec!["add"], "--v", vec![], 3);
+        let context = CompletionContext::new(vec!["add"], "--v");
         let result = compute_completions(&command_refs, &machine, &context);
 
         // Should only suggest --verbose
@@ -508,14 +578,38 @@ mod tests {
         let command_refs: Vec<&CommandSpec> = specs.iter().collect();
 
         // After using --verbose, it should not be suggested again
-        let context = CompletionContext::new(vec!["add", "--verbose"], "-", vec![], 1);
+        let context = CompletionContext::new(vec!["add", "--verbose"], "-");
         let result = compute_completions(&command_refs, &machine, &context);
 
         let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
-        assert!(!texts.contains(&"--verbose")); // Should be filtered out
-        assert!(!texts.contains(&"-v")); // Alias should also be filtered out
-        assert!(texts.contains(&"-m")); // Other options should still be available
-        assert!(texts.contains(&"--message"));
+        assert!(!texts.contains(&"--verbose")); // Should be filtered out (already used)
+        assert!(!texts.contains(&"-v")); // Short options are filtered out
+        assert!(!texts.contains(&"-m")); // Short options are filtered out
+        assert!(texts.contains(&"--message")); // Other long options should still be available
+    }
+
+    #[test]
+    fn test_no_options_when_path_incomplete() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // When no command has been typed yet, options should not be suggested
+        // even if the current token looks like an option
+        let context = CompletionContext::new(vec![], "-");
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        // Should only have command paths, no options
+        assert!(!texts.contains(&"-v"));
+        assert!(!texts.contains(&"--verbose"));
+        assert!(!texts.contains(&"-m"));
+        assert!(!texts.contains(&"--message"));
     }
 
     #[test]
@@ -541,7 +635,7 @@ mod tests {
         assert!(script.contains("compdef _my_cli my-cli")); // Function name has underscores
         assert!(script.contains("--clipanion-complete"));
         assert!(script.contains("-- \"${words[@]:1}\"")); // Uses -- separator
-        assert!(script.contains("compadd -a completions")); // Uses compadd
+        assert!(script.contains("_describe 'completion' completions")); // Uses _describe for descriptions
     }
 
     #[test]
@@ -557,5 +651,156 @@ mod tests {
         let script = generate_completion_script(Shell::Bash, "/usr/local/bin/my-cli");
         // Should extract binary name from path
         assert!(script.contains("complete -F _my-cli_completions my-cli"));
+    }
+
+    fn branch_completer(current: &str) -> Vec<Completion> {
+        let branches = vec!["main", "develop", "feature/login", "feature/search"];
+        branches.into_iter()
+            .filter(|b| b.starts_with(current))
+            .map(|b| Completion::new(b))
+            .collect()
+    }
+
+    #[test]
+    fn test_positional_completer() {
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["checkout".to_string()],
+                components: vec![
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "BRANCH".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: Some(0),
+                        is_prefix: false,
+                        is_proxy: false,
+                        completer: Some(branch_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // Complete with empty input after "checkout"
+        let context = CompletionContext::new(vec!["checkout"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"main"));
+        assert!(texts.contains(&"develop"));
+        assert!(texts.contains(&"feature/login"));
+        assert!(texts.contains(&"feature/search"));
+
+        // Complete with partial input
+        let context = CompletionContext::new(vec!["checkout"], "fe");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(!texts.contains(&"main"));
+        assert!(!texts.contains(&"develop"));
+        assert!(texts.contains(&"feature/login"));
+        assert!(texts.contains(&"feature/search"));
+    }
+
+    #[test]
+    fn test_positional_without_completer() {
+        // Positionals without a completer should produce no positional completions
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["checkout".to_string()],
+                components: vec![
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "BRANCH".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: Some(0),
+                        is_prefix: false,
+                        is_proxy: false,
+                        completer: None,
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        let context = CompletionContext::new(vec!["checkout"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        assert!(result.completions.is_empty());
+    }
+
+    fn script_completer(current: &str) -> Vec<Completion> {
+        let scripts = vec!["build", "test", "lint", "start"];
+        scripts.into_iter()
+            .filter(|s| s.starts_with(current))
+            .map(|s| Completion::new(s))
+            .collect()
+    }
+
+    #[test]
+    fn test_proxy_positional_completer() {
+        // A proxy positional captures all remaining args (including option-like ones).
+        // Its completer should still be invoked.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["run".to_string()],
+                components: vec![
+                    Component::Positional(PositionalSpec::Dynamic {
+                        name: "SCRIPT".to_string(),
+                        documentation: None,
+                        min_len: 1,
+                        extra_len: None,
+                        is_prefix: false,
+                        is_proxy: true,
+                        completer: Some(script_completer),
+                    }),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // Complete first proxy arg
+        let context = CompletionContext::new(vec!["run"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"build"));
+        assert!(texts.contains(&"test"));
+        assert!(texts.contains(&"lint"));
+        assert!(texts.contains(&"start"));
+
+        // Complete with partial input
+        let context = CompletionContext::new(vec!["run"], "t");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"test"));
+        assert!(!texts.contains(&"build"));
+
+        // Complete subsequent proxy arg (should still invoke completer via PushValue)
+        let context = CompletionContext::new(vec!["run", "test"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"build"));
+        assert!(texts.contains(&"test"));
     }
 }

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -157,13 +157,12 @@ pub fn compute_completions<'cmds, 'args>(
         }
 
         // Collect dynamic transitions (options and positionals)
-        // Only suggest if this specific state's command has a complete path
+        // Only suggest if no keyword transition is reachable from the current
+        // node (including through shortcuts), meaning the command path has been
+        // fully consumed. This works for aliases of any length.
         let state_has_complete_path
-            = if let Some(cmd) = command {
-                state.keyword_count >= cmd.primary_path.len()
-            } else {
-                false
-            };
+            = command.is_some()
+                && !has_reachable_keyword(machine, state.node_id);
 
         if state_has_complete_path {
             // Collect matching option completions for this state first, then
@@ -277,6 +276,36 @@ fn insert_completion(map: &mut BTreeMap<String, Completion>, completion: Complet
             }
         }
     }
+}
+
+/// Check whether a keyword transition is reachable from the given node,
+/// either directly or through shortcuts. If a keyword is reachable, it
+/// means the command path hasn't been fully consumed yet.
+fn has_reachable_keyword(machine: &CliMachine, start_node_id: usize) -> bool {
+    let mut visited
+        = std::collections::HashSet::new();
+
+    let mut stack
+        = vec![start_node_id];
+
+    while let Some(node_id) = stack.pop() {
+        if !visited.insert(node_id) {
+            continue;
+        }
+
+        let node
+            = &machine.nodes[node_id];
+
+        if node.statics.keys().any(|k| matches!(k, ArgKey::User(_))) {
+            return true;
+        }
+
+        for shortcut in &node.shortcuts {
+            stack.push(shortcut.to);
+        }
+    }
+
+    false
 }
 
 fn find_option_with_id_by_name<'cmds>(command: &'cmds CommandSpec, name: &str) -> Option<(usize, &'cmds OptionSpec)> {
@@ -899,6 +928,60 @@ mod tests {
             = result.completions.iter().map(|c| c.text.as_str()).collect();
 
         assert!(texts.contains(&"--verbose"), "after full path, options should appear, got: {:?}", texts);
+    }
+
+    #[test]
+    fn test_options_with_shorter_alias() {
+        // A command with a long primary path and a shorter alias should
+        // show options when the alias is fully typed, not only when the
+        // primary path is fully typed.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "list".to_string()],
+                aliases: vec![vec!["workspaces".to_string()]],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--json")),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder
+            = CliBuilder::new();
+
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+
+        let machine
+            = builder.compile();
+
+        let command_refs: Vec<&CommandSpec>
+            = specs.iter().collect();
+
+        // `workspaces --<TAB>` — alias path is complete
+        let context
+            = CompletionContext::new(vec!["workspaces"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
+
+        assert!(texts.contains(&"--json"), "options should appear after completing the alias path, got: {:?}", texts);
+
+        // `workspace list --<TAB>` — primary path is also complete
+        let context
+            = CompletionContext::new(vec!["workspace", "list"], "--");
+
+        let result
+            = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str>
+            = result.completions.iter().map(|c| c.text.as_str()).collect();
+
+        assert!(texts.contains(&"--json"), "options should appear after completing the primary path, got: {:?}", texts);
     }
 
     #[test]

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -99,18 +99,6 @@ pub fn compute_completions<'cmds, 'args>(
     // Run the machine with the arguments before the current token to get the current states
     let states = run_machine_partial(machine, &context.args_before);
 
-    // Check if any state has a complete path (has reached a command)
-    let has_complete_path = states.iter().any(|state| {
-        if state.node_id == ERROR_NODE_ID {
-            return false;
-        }
-        if let Some(cmd) = commands.get(state.context_id) {
-            state.keyword_count >= cmd.primary_path.len()
-        } else {
-            false
-        }
-    });
-
     // Now analyze each state to find valid completions
     let mut completions = BTreeSet::new();
 
@@ -140,8 +128,14 @@ pub fn compute_completions<'cmds, 'args>(
         }
 
         // Collect dynamic transitions (options and positionals)
-        // Only suggest if at least one state has a complete path (reached a command)
-        if has_complete_path {
+        // Only suggest if this specific state's command has a complete path
+        let state_has_complete_path = if let Some(cmd) = command {
+            state.keyword_count >= cmd.primary_path.len()
+        } else {
+            false
+        };
+
+        if state_has_complete_path {
             for (check, transition) in &node.dynamics {
                 match check {
                     Some(Check::IsOption(name)) => {
@@ -619,6 +613,52 @@ mod tests {
         assert!(!texts.contains(&"--verbose"));
         assert!(!texts.contains(&"-m"));
         assert!(!texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_no_options_from_longer_path_when_shorter_path_complete() {
+        // Command A: path = ["workspace"] with --json
+        // Command B: path = ["workspace", "run"] with --verbose
+        // After typing "workspace", only A's path is complete.
+        // B's --verbose should NOT be suggested.
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["workspace".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--json")),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "run".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("--verbose")),
+                ],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // `workspace --<TAB>` — only "workspace" command's path is complete
+        let context = CompletionContext::new(vec!["workspace"], "--");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+
+        assert!(texts.contains(&"--json"), "complete command's options should appear, got: {:?}", texts);
+        assert!(!texts.contains(&"--verbose"), "incomplete path command's options should NOT appear, got: {:?}", texts);
+
+        // `workspace run --<TAB>` — now both paths are complete
+        let context = CompletionContext::new(vec!["workspace", "run"], "--");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+
+        assert!(texts.contains(&"--verbose"), "after full path, options should appear, got: {:?}", texts);
     }
 
     #[test]

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 use crate::{
     builder::{Attachment, Check, CommandSpec, Component, OptionSpec, PositionalSpec, Reducer, State},
@@ -100,7 +100,9 @@ pub fn compute_completions<'cmds, 'args>(
     let states = run_machine_partial(machine, &context.args_before);
 
     // Now analyze each state to find valid completions
-    let mut completions = BTreeSet::new();
+    // Use a BTreeMap keyed by text so that entries with descriptions
+    // take precedence over bare entries for the same keyword.
+    let mut completions: BTreeMap<String, Completion> = BTreeMap::new();
 
     for state in &states {
         if state.node_id == ERROR_NODE_ID {
@@ -122,7 +124,27 @@ pub fn compute_completions<'cmds, 'args>(
             if let ArgKey::User(keyword) = key {
                 // Check if the current partial matches
                 if keyword.starts_with(context.current) {
-                    completions.insert(Completion::new(*keyword).as_path());
+                    let mut completion = Completion::new(*keyword).as_path();
+
+                    // If this keyword is the last segment of the command's path,
+                    // attach the command's description.
+                    if let Some(cmd) = command {
+                        let idx = state.keyword_count;
+                        let is_last_segment = |path: &[String]| {
+                            idx + 1 == path.len()
+                                && path.get(idx).map_or(false, |s| s.as_str() == *keyword)
+                        };
+
+                        if is_last_segment(&cmd.primary_path)
+                            || cmd.aliases.iter().any(|a| is_last_segment(a))
+                        {
+                            if let Some(doc) = &cmd.documentation {
+                                completion = completion.with_description(doc.description.clone());
+                            }
+                        }
+                    }
+
+                    insert_completion(&mut completions, completion);
                 }
             }
         }
@@ -136,46 +158,53 @@ pub fn compute_completions<'cmds, 'args>(
         };
 
         if state_has_complete_path {
-            for (check, transition) in &node.dynamics {
-                match check {
-                    Some(Check::IsOption(name)) => {
-                        // Don't suggest -- or -h/--help which are special
-                        if *name == "--" || *name == "-h" || *name == "--help" {
-                            continue;
-                        }
+            // Collect matching option completions for this state first, then
+            // only include undescribed options when no described option matches.
+            let mut option_candidates: Vec<Completion> = Vec::new();
 
-                        // Only suggest long options (--foo), not short options (-f)
-                        if !name.starts_with("--") {
-                            continue;
-                        }
-
-                        // Check if the current partial matches
-                        if name.starts_with(context.current) {
-                            // Find the option spec to check if it's already used
-                            if let Some(cmd) = command {
-                                if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
-                                    // Skip options that are already used and don't accept multiple values
-                                    let is_single_use = opt.extra_len.is_some();
-                                    if is_single_use && used_option_ids.contains(&component_id) {
-                                        continue;
-                                    }
-
-                                    let description = opt.documentation.as_ref()
-                                        .map(|doc| doc.description.clone());
-
-                                    let mut completion = Completion::new(*name).as_option();
-                                    if let Some(desc) = description {
-                                        completion = completion.with_description(desc);
-                                    }
-                                    completions.insert(completion);
-                                }
-                            } else {
-                                // No command context, just add the option
-                                completions.insert(Completion::new(*name).as_option());
-                            }
-                        }
+            for (check, _) in &node.dynamics {
+                if let Some(Check::IsOption(name)) = check {
+                    // Don't suggest -- or -h/--help which are special
+                    if *name == "--" || *name == "-h" || *name == "--help" {
+                        continue;
                     }
 
+                    // Only suggest long options (--foo), not short options (-f)
+                    if !name.starts_with("--") {
+                        continue;
+                    }
+
+                    // Check if the current partial matches
+                    if name.starts_with(context.current) {
+                        if let Some(cmd) = command {
+                            if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
+                                let is_single_use = opt.extra_len.is_some();
+                                if is_single_use && used_option_ids.contains(&component_id) {
+                                    continue;
+                                }
+
+                                let mut completion = Completion::new(*name).as_option();
+                                if let Some(doc) = &opt.documentation {
+                                    completion = completion.with_description(doc.description.clone());
+                                }
+                                option_candidates.push(completion);
+                            }
+                        } else {
+                            option_candidates.push(Completion::new(*name).as_option());
+                        }
+                    }
+                }
+            }
+
+            let has_any_described = option_candidates.iter().any(|c| c.description.is_some());
+            for c in option_candidates {
+                if !has_any_described || c.description.is_some() {
+                    insert_completion(&mut completions, c);
+                }
+            }
+
+            for (check, transition) in &node.dynamics {
+                match check {
                     Some(Check::IsNotOptionLike) | None => {
                         // Positional argument — invoke completer if available
                         if let Some(cmd) = command {
@@ -199,7 +228,7 @@ pub fn compute_completions<'cmds, 'args>(
                                     let local_context = CompletionContext::new(positional_args, context.current);
 
                                     for c in f(&local_context) {
-                                        completions.insert(c);
+                                        insert_completion(&mut completions, c);
                                     }
                                 }
                             }
@@ -214,7 +243,21 @@ pub fn compute_completions<'cmds, 'args>(
     }
 
     CompletionResult {
-        completions: completions.into_iter().collect(),
+        completions: completions.into_values().collect(),
+    }
+}
+
+/// Insert a completion into the map, preferring entries that carry a description.
+fn insert_completion(map: &mut BTreeMap<String, Completion>, completion: Completion) {
+    match map.entry(completion.text.clone()) {
+        std::collections::btree_map::Entry::Vacant(e) => {
+            e.insert(completion);
+        }
+        std::collections::btree_map::Entry::Occupied(mut e) => {
+            if completion.description.is_some() && e.get().description.is_none() {
+                e.insert(completion);
+            }
+        }
     }
 }
 
@@ -438,7 +481,7 @@ complete -c {binary_name} -f -a '(__fish_{binary_name}_completions)'
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{builder::CliBuilder, PositionalSpec};
+    use crate::{builder::{CliBuilder, Documentation}, PositionalSpec};
 
     fn create_simple_cli() -> Vec<CommandSpec> {
         vec![
@@ -613,6 +656,62 @@ mod tests {
         assert!(!texts.contains(&"--verbose"));
         assert!(!texts.contains(&"-m"));
         assert!(!texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_keyword_completions_include_command_description() {
+        let specs = vec![
+            CommandSpec {
+                primary_path: vec!["add".to_string()],
+                documentation: Some(Documentation::new("Add files to staging", None)),
+                components: vec![],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["commit".to_string()],
+                documentation: Some(Documentation::new("Record changes", None)),
+                components: vec![],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "run".to_string()],
+                documentation: Some(Documentation::new("Run a workspace script", None)),
+                components: vec![],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["workspace".to_string(), "list".to_string()],
+                documentation: Some(Documentation::new("List workspaces", None)),
+                components: vec![],
+                ..Default::default()
+            },
+        ];
+
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // Top-level: single-segment commands get their description
+        let context = CompletionContext::new(vec![], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let add = result.completions.iter().find(|c| c.text == "add").unwrap();
+        assert_eq!(add.description.as_deref(), Some("Add files to staging"));
+        let commit = result.completions.iter().find(|c| c.text == "commit").unwrap();
+        assert_eq!(commit.description.as_deref(), Some("Record changes"));
+        // "workspace" is not a final segment, so no description
+        let workspace = result.completions.iter().find(|c| c.text == "workspace").unwrap();
+        assert_eq!(workspace.description, None);
+
+        // After "workspace": "run" and "list" are final segments and get descriptions
+        let context = CompletionContext::new(vec!["workspace"], "");
+        let result = compute_completions(&command_refs, &machine, &context);
+        let run = result.completions.iter().find(|c| c.text == "run").unwrap();
+        assert_eq!(run.description.as_deref(), Some("Run a workspace script"));
+        let list = result.completions.iter().find(|c| c.text == "list").unwrap();
+        assert_eq!(list.description.as_deref(), Some("List workspaces"));
     }
 
     #[test]

--- a/packages/clipanion-core/src/completion.rs
+++ b/packages/clipanion-core/src/completion.rs
@@ -1,0 +1,561 @@
+use std::collections::BTreeSet;
+
+use crate::{
+    builder::{Check, CommandSpec, Component, OptionSpec, Reducer, State},
+    runner::{Runner, RunnerState},
+    shared::{Arg, ArgKey, ERROR_NODE_ID},
+    Machine,
+};
+
+/// A single completion candidate
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct Completion {
+    /// The completion text
+    pub text: String,
+
+    /// Description of this completion
+    pub description: Option<String>,
+
+    /// Whether this completion represents a path/command keyword
+    pub is_path: bool,
+
+    /// Whether this completion represents an option
+    pub is_option: bool,
+}
+
+impl Completion {
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            description: None,
+            is_path: false,
+            is_option: false,
+        }
+    }
+
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn as_path(mut self) -> Self {
+        self.is_path = true;
+        self
+    }
+
+    pub fn as_option(mut self) -> Self {
+        self.is_option = true;
+        self
+    }
+}
+
+/// Context for completion computation
+#[derive(Debug, Clone)]
+pub struct CompletionContext<'a> {
+    /// Arguments before the current token
+    pub args_before: Vec<&'a str>,
+
+    /// The partial token being completed (empty if cursor is between tokens)
+    pub current: &'a str,
+
+    /// Arguments after the current token
+    pub args_after: Vec<&'a str>,
+
+    /// Position of cursor within the current token (0 = beginning)
+    pub cursor_position: usize,
+}
+
+impl<'a> CompletionContext<'a> {
+    pub fn new(args_before: Vec<&'a str>, current: &'a str, args_after: Vec<&'a str>, cursor_position: usize) -> Self {
+        Self {
+            args_before,
+            current,
+            args_after,
+            cursor_position,
+        }
+    }
+
+    /// Create a context from a full command line where the cursor is at the end
+    pub fn from_args_at_end(args: Vec<&'a str>) -> Self {
+        if args.is_empty() {
+            Self::new(vec![], "", vec![], 0)
+        } else {
+            let last_arg = args[args.len() - 1];
+            Self::new(args[..args.len() - 1].to_vec(), last_arg, vec![], last_arg.len())
+        }
+    }
+}
+
+/// Result of completion computation
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct CompletionResult {
+    pub completions: Vec<Completion>,
+}
+
+type CliMachine<'cmds> = Machine<'cmds, Option<Check<'cmds>>, Option<Reducer>>;
+
+/// Compute completions for a CLI given the current context
+pub fn compute_completions<'cmds, 'args>(
+    commands: &[&'cmds CommandSpec],
+    machine: &CliMachine<'cmds>,
+    context: &CompletionContext<'args>,
+) -> CompletionResult {
+    // Run the machine with the arguments before the current token to get the current states
+    let states = run_machine_partial(machine, &context.args_before);
+
+    // Now analyze each state to find valid completions
+    let mut completions = BTreeSet::new();
+
+    for state in &states {
+        if state.node_id == ERROR_NODE_ID {
+            continue;
+        }
+
+        let node = &machine.nodes[state.node_id];
+        let command = commands.get(state.context_id);
+
+        // Build a set of already-used option component IDs
+        let used_option_ids: std::collections::HashSet<usize> = state
+            .option_values
+            .iter()
+            .map(|(id, _)| *id)
+            .collect();
+
+        // Collect static transitions (command paths, keywords)
+        for (key, _transitions) in &node.statics {
+            if let ArgKey::User(keyword) = key {
+                // Check if the current partial matches
+                if keyword.starts_with(context.current) {
+                    completions.insert(Completion::new(*keyword).as_path());
+                }
+            }
+        }
+
+        // Collect dynamic transitions (options)
+        for (check, _transition) in &node.dynamics {
+            if let Some(Check::IsOption(name)) = check {
+                // Don't suggest -- or -h/--help which are special
+                if *name == "--" || *name == "-h" || *name == "--help" {
+                    continue;
+                }
+
+                // Check if the current partial matches
+                if name.starts_with(context.current) {
+                    // Find the option spec to check if it's already used
+                    if let Some(cmd) = command {
+                        if let Some((component_id, opt)) = find_option_with_id_by_name(cmd, name) {
+                            // Skip options that are already used and don't accept multiple values
+                            let is_single_use = opt.min_len == 0 && opt.extra_len == Some(0);
+                            if is_single_use && used_option_ids.contains(&component_id) {
+                                continue;
+                            }
+
+                            let description = opt.documentation.as_ref()
+                                .map(|doc| doc.description.clone());
+
+                            let mut completion = Completion::new(*name).as_option();
+                            if let Some(desc) = description {
+                                completion = completion.with_description(desc);
+                            }
+                            completions.insert(completion);
+                        }
+                    } else {
+                        // No command context, just add the option
+                        completions.insert(Completion::new(*name).as_option());
+                    }
+                }
+            }
+        }
+
+        // If current starts with -, filter to only options
+        if !context.current.is_empty() && context.current.starts_with("-") && !state.post_double_dash {
+            // Only show options
+            completions.retain(|c| c.is_option);
+        }
+    }
+
+    CompletionResult {
+        completions: completions.into_iter().collect(),
+    }
+}
+
+fn find_option_with_id_by_name<'cmds>(command: &'cmds CommandSpec, name: &str) -> Option<(usize, &'cmds OptionSpec)> {
+    command.components.iter().enumerate().find_map(|(id, component)| {
+        if let Component::Option(opt) = component {
+            if opt.all_names().any(|n| n == name) {
+                return Some((id, opt));
+            }
+        }
+        None
+    })
+}
+
+fn run_machine_partial<'cmds, 'args>(
+    machine: &CliMachine<'cmds>,
+    args: &[&'args str],
+) -> Vec<State<'args>> {
+    fn on_error<'args>(mut state: State<'args>, _: Arg<'args>) -> State<'args> {
+        state.set_node_id(ERROR_NODE_ID);
+        state
+    }
+
+    Runner::run_partial(machine, on_error, args)
+}
+
+/// Generate shell completion script
+pub fn generate_completion_script(shell: Shell, command: &str) -> String {
+    match shell {
+        Shell::Bash => generate_bash_script(command),
+        Shell::Zsh => generate_zsh_script(command),
+        Shell::Fish => generate_fish_script(command),
+    }
+}
+
+/// Supported shells for completion scripts
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Shell {
+    Bash,
+    Zsh,
+    Fish,
+}
+
+impl Shell {
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "bash" => Some(Shell::Bash),
+            "zsh" => Some(Shell::Zsh),
+            "fish" => Some(Shell::Fish),
+            _ => None,
+        }
+    }
+
+    pub fn detect() -> Option<Self> {
+        std::env::var("SHELL")
+            .ok()
+            .and_then(|s| {
+                let shell_name = s.rsplit('/').next()?;
+                Self::from_str(shell_name)
+            })
+    }
+}
+
+fn generate_bash_script(command: &str) -> String {
+    // Extract the binary name from the command (last path component, no arguments)
+    let binary_name = command
+        .split_whitespace()
+        .next()
+        .unwrap_or(command)
+        .rsplit('/')
+        .next()
+        .unwrap_or(command);
+
+    format!(
+        r#"# Bash completion script for {binary_name}
+# Generated by clipanion-rs
+# Add this to your ~/.bashrc or source it directly
+
+_{binary_name}_completions() {{
+    local cur prev words cword
+    _init_completion || return
+
+    local IFS=$'\n'
+    local completions
+    # cword is 1-based and includes the command name, so subtract 1 for 0-based index without command
+    local index=$((cword - 1))
+    completions=$({command} --clipanion-complete "$index" -- "${{words[@]:1}}" 2>/dev/null)
+
+    if [[ -n "$completions" ]]; then
+        COMPREPLY=($(compgen -W "$completions" -- "$cur"))
+    fi
+}}
+
+complete -F _{binary_name}_completions {binary_name}
+"#,
+        binary_name = binary_name,
+        command = command,
+    )
+}
+
+fn generate_zsh_script(command: &str) -> String {
+    let binary_name = command
+        .split_whitespace()
+        .next()
+        .unwrap_or(command)
+        .rsplit('/')
+        .next()
+        .unwrap_or(command);
+
+    // Replace hyphens with underscores for valid zsh function name
+    let func_name = binary_name.replace('-', "_");
+
+    format!(
+        r#"# Zsh completion script for {binary_name}
+# Generated by clipanion-rs
+# Add this to your ~/.zshrc or place in a file in your $fpath
+
+_{func_name}() {{
+    local -a completions
+    local line
+
+    # CURRENT is 1-based and includes command name, convert to 0-based index without command
+    local index=$((CURRENT - 2))
+
+    # Get completions from the CLI
+    while IFS= read -r line; do
+        completions+=("$line")
+    done < <({command} --clipanion-complete "$index" -- "${{words[@]:1}}" 2>/dev/null)
+
+    # Add completions
+    if (( $#completions )); then
+        compadd -a completions
+    fi
+}}
+
+compdef _{func_name} {binary_name}
+"#,
+        binary_name = binary_name,
+        func_name = func_name,
+        command = command,
+    )
+}
+
+fn generate_fish_script(command: &str) -> String {
+    let binary_name = command
+        .split_whitespace()
+        .next()
+        .unwrap_or(command)
+        .rsplit('/')
+        .next()
+        .unwrap_or(command);
+
+    format!(
+        r#"# Fish completion script for {binary_name}
+# Generated by clipanion-rs
+# Save this file to ~/.config/fish/completions/{binary_name}.fish
+
+function __fish_{binary_name}_completions
+    set -l tokens (commandline -opc)
+    set -l current (commandline -ct)
+
+    # Remove the command name itself (first token)
+    set -e tokens[1]
+
+    # Count tokens to get the index (current token position)
+    set -l index (count $tokens)
+
+    # Add the current token to the args if it's not empty
+    if test -n "$current"
+        set tokens $tokens "$current"
+    end
+
+    {command} --clipanion-complete "$index" -- $tokens 2>/dev/null
+end
+
+complete -c {binary_name} -f -a '(__fish_{binary_name}_completions)'
+"#,
+        binary_name = binary_name,
+        command = command,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{builder::CliBuilder, PositionalSpec};
+
+    fn create_simple_cli() -> Vec<CommandSpec> {
+        vec![
+            CommandSpec {
+                primary_path: vec!["add".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("-v,--verbose")),
+                    Component::Option(OptionSpec::parametrized("-m,--message")),
+                    Component::Positional(PositionalSpec::rest()),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["commit".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("-a,--all")),
+                    Component::Option(OptionSpec::parametrized("-m,--message")),
+                ],
+                ..Default::default()
+            },
+            CommandSpec {
+                primary_path: vec!["checkout".to_string()],
+                components: vec![
+                    Component::Option(OptionSpec::boolean("-b")),
+                    Component::Positional(PositionalSpec::optional()),
+                ],
+                ..Default::default()
+            },
+        ]
+    }
+
+    #[test]
+    fn test_complete_empty_input() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let context = CompletionContext::new(vec![], "", vec![], 0);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        // Should suggest command paths
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"add"));
+        assert!(texts.contains(&"commit"));
+        assert!(texts.contains(&"checkout"));
+    }
+
+    #[test]
+    fn test_complete_partial_command() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let context = CompletionContext::new(vec![], "co", vec![], 2);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        // Should only suggest commands starting with "co" (commit, not checkout which starts with "ch")
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"commit"));
+        assert!(!texts.contains(&"checkout")); // checkout starts with "ch", not "co"
+        assert!(!texts.contains(&"add"));
+    }
+
+    #[test]
+    fn test_complete_options_after_command() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let context = CompletionContext::new(vec!["add"], "-", vec![], 1);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        // Should suggest options for 'add' command
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"-v"));
+        assert!(texts.contains(&"--verbose"));
+        assert!(texts.contains(&"-m"));
+        assert!(texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_complete_long_option_prefix() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let context = CompletionContext::new(vec!["add"], "--v", vec![], 3);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        // Should only suggest --verbose
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"--verbose"));
+        assert!(!texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_complete_from_args_at_end() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+        let context = CompletionContext::from_args_at_end(vec!["add", "--"]);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        // Should suggest long options
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(texts.contains(&"--verbose"));
+        assert!(texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_filter_already_used_options() {
+        let specs = create_simple_cli();
+        let mut builder = CliBuilder::new();
+        for spec in &specs {
+            builder.add_command(spec);
+        }
+        let machine = builder.compile();
+
+        let command_refs: Vec<&CommandSpec> = specs.iter().collect();
+
+        // After using --verbose, it should not be suggested again
+        let context = CompletionContext::new(vec!["add", "--verbose"], "-", vec![], 1);
+        let result = compute_completions(&command_refs, &machine, &context);
+
+        let texts: Vec<&str> = result.completions.iter().map(|c| c.text.as_str()).collect();
+        assert!(!texts.contains(&"--verbose")); // Should be filtered out
+        assert!(!texts.contains(&"-v")); // Alias should also be filtered out
+        assert!(texts.contains(&"-m")); // Other options should still be available
+        assert!(texts.contains(&"--message"));
+    }
+
+    #[test]
+    fn test_shell_detection() {
+        assert_eq!(Shell::from_str("bash"), Some(Shell::Bash));
+        assert_eq!(Shell::from_str("BASH"), Some(Shell::Bash));
+        assert_eq!(Shell::from_str("zsh"), Some(Shell::Zsh));
+        assert_eq!(Shell::from_str("fish"), Some(Shell::Fish));
+        assert_eq!(Shell::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn test_bash_script_generation() {
+        let script = generate_completion_script(Shell::Bash, "my-cli");
+        assert!(script.contains("complete -F _my-cli_completions my-cli"));
+        assert!(script.contains("--clipanion-complete"));
+        assert!(script.contains("-- \"${words[@]:1}\"")); // Uses -- separator
+    }
+
+    #[test]
+    fn test_zsh_script_generation() {
+        let script = generate_completion_script(Shell::Zsh, "my-cli");
+        assert!(script.contains("compdef _my_cli my-cli")); // Function name has underscores
+        assert!(script.contains("--clipanion-complete"));
+        assert!(script.contains("-- \"${words[@]:1}\"")); // Uses -- separator
+        assert!(script.contains("compadd -a completions")); // Uses compadd
+    }
+
+    #[test]
+    fn test_fish_script_generation() {
+        let script = generate_completion_script(Shell::Fish, "my-cli");
+        assert!(script.contains("complete -c my-cli"));
+        assert!(script.contains("--clipanion-complete"));
+        assert!(script.contains("-- $tokens")); // Uses -- separator
+    }
+
+    #[test]
+    fn test_script_with_path_command() {
+        let script = generate_completion_script(Shell::Bash, "/usr/local/bin/my-cli");
+        // Should extract binary name from path
+        assert!(script.contains("complete -F _my-cli_completions my-cli"));
+    }
+}

--- a/packages/clipanion-core/src/fuzzy_tests.rs
+++ b/packages/clipanion-core/src/fuzzy_tests.rs
@@ -63,6 +63,7 @@ fn gen_random_positional_spec<R: Rng>(rng: &mut R, use_optional_positionals: boo
             },
             is_prefix: false,
             is_proxy: false,
+            completer: None,
         },
 
         _ => unreachable!(),

--- a/packages/clipanion-core/src/lib.rs
+++ b/packages/clipanion-core/src/lib.rs
@@ -10,9 +10,11 @@ mod usage;
 mod fuzzy_tests;
 
 pub mod builder;
+pub mod completion;
 pub mod runner;
 
 pub use builder::*;
+pub use completion::*;
 pub use errors::*;
 pub use machine::Machine;
 pub use runner::*;

--- a/packages/clipanion-core/src/selector.rs
+++ b/packages/clipanion-core/src/selector.rs
@@ -299,25 +299,21 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
             .collect();
     }
 
-    fn handle_everything_is_an_error<T>(&mut self) -> Result<SelectionResult<'cmds, 'args, T>, Error<'cmds>> {
-        if self.args.len() == 1 && matches!(self.args[0], "--version" | "-v") {
-            return Ok(SelectionResult::Builtin(BuiltinCommand::Version));
+    fn check_clipanion_builtins(&self) -> Option<BuiltinCommand<'cmds, 'args>> {
+        if self.args.is_empty() {
+            return None;
         }
 
-        if self.args.len() == 1 && matches!(self.args[0], "--help" | "-h") {
-            return Ok(SelectionResult::Builtin(BuiltinCommand::Help(vec![])));
+        if self.args[0] == "--clipanion-commands" && self.args.len() == 1 {
+            return Some(BuiltinCommand::Describe);
         }
 
-        if self.args.len() == 1 && matches!(self.args[0], "--clipanion-commands") {
-            return Ok(SelectionResult::Builtin(BuiltinCommand::Describe));
-        }
-
-        if self.args.len() > 0 && self.args[0].starts_with("--clipanion-tokens") {
-            return Ok(SelectionResult::Builtin(BuiltinCommand::Tokenize(self.args[1..].to_vec())));
+        if self.args[0].starts_with("--clipanion-tokens") {
+            return Some(BuiltinCommand::Tokenize(self.args[1..].to_vec()));
         }
 
         // Handle --clipanion-completion-script [--shell <shell>] [--command <command>]
-        if self.args.len() > 0 && self.args[0] == "--clipanion-completion-script" {
+        if self.args[0] == "--clipanion-completion-script" {
             let mut shell = None;
             let mut command = None;
             let mut i = 1;
@@ -334,32 +330,37 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
                     _ => i += 1,
                 }
             }
-            return Ok(SelectionResult::Builtin(BuiltinCommand::CompletionScript { shell, command }));
+            return Some(BuiltinCommand::CompletionScript { shell, command });
         }
 
         // Handle --clipanion-complete <index> -- <args...>
-        // The index is the 0-based position of the argument being completed
-        // Everything after -- is the user's command line (without binary name)
-        if self.args.len() > 0 && self.args[0] == "--clipanion-complete" {
-            // Find the -- separator
+        if self.args[0] == "--clipanion-complete" {
             let separator_pos = self.args.iter().position(|&arg| arg == "--");
 
             if let Some(sep_pos) = separator_pos {
-                // Parse index (should be at position 1)
                 let index = if sep_pos > 1 {
                     self.args[1].parse::<usize>().unwrap_or(0)
                 } else {
                     0
                 };
 
-                // Everything after -- is the user's arguments
                 let args = self.args[sep_pos + 1..].to_vec();
-
-                return Ok(SelectionResult::Builtin(BuiltinCommand::Complete { index, args }));
+                return Some(BuiltinCommand::Complete { index, args });
             } else {
-                // Fallback: no separator, assume empty completion
-                return Ok(SelectionResult::Builtin(BuiltinCommand::Complete { index: 0, args: vec![] }));
+                return Some(BuiltinCommand::Complete { index: 0, args: vec![] });
             }
+        }
+
+        None
+    }
+
+    fn handle_everything_is_an_error<T>(&mut self) -> Result<SelectionResult<'cmds, 'args, T>, Error<'cmds>> {
+        if self.args.len() == 1 && matches!(self.args[0], "--version" | "-v") {
+            return Ok(SelectionResult::Builtin(BuiltinCommand::Version));
+        }
+
+        if self.args.len() == 1 && matches!(self.args[0], "--help" | "-h") {
+            return Ok(SelectionResult::Builtin(BuiltinCommand::Help(vec![])));
         }
 
         self.candidates = (0..self.states.len()).collect();
@@ -381,6 +382,14 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
     }
 
     pub fn resolve_state<F: Fn(&State<'args>) -> Result<T, CommandError>, T>(&mut self, f: F) -> Result<SelectionResult<'cmds, 'args, T>, Error<'cmds>> {
+        // Framework-internal flags (--clipanion-*) must be intercepted unconditionally,
+        // before any candidate filtering. These are never user-facing — they're only
+        // invoked by scripts the framework itself generates. Without this early check,
+        // a root-level proxy command would swallow them as proxy arguments.
+        if let Some(builtin) = self.check_clipanion_builtins() {
+            return Ok(SelectionResult::Builtin(builtin));
+        }
+
         if std::env::var("CLIPANION_DEBUG").is_ok() {
             println!("========== Pre-selection states ==========");
 

--- a/packages/clipanion-core/src/selector.rs
+++ b/packages/clipanion-core/src/selector.rs
@@ -314,9 +314,13 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
 
         // Handle --clipanion-completion-script [--shell <shell>] [--command <command>]
         if self.args[0] == "--clipanion-completion-script" {
-            let mut shell = None;
-            let mut command = None;
-            let mut i = 1;
+            let mut shell
+                = None;
+            let mut command
+                = None;
+            let mut i
+                = 1;
+
             while i < self.args.len() {
                 match self.args[i] {
                     "--shell" if i + 1 < self.args.len() => {
@@ -330,21 +334,26 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
                     _ => i += 1,
                 }
             }
+
             return Some(BuiltinCommand::CompletionScript { shell, command });
         }
 
         // Handle --clipanion-complete <index> -- <args...>
         if self.args[0] == "--clipanion-complete" {
-            let separator_pos = self.args.iter().position(|&arg| arg == "--");
+            let separator_pos
+                = self.args.iter().position(|&arg| arg == "--");
 
             if let Some(sep_pos) = separator_pos {
-                let index = if sep_pos > 1 {
-                    self.args[1].parse::<usize>().unwrap_or(0)
-                } else {
-                    0
-                };
+                let index
+                    = if sep_pos > 1 {
+                        self.args[1].parse::<usize>().unwrap_or(0)
+                    } else {
+                        0
+                    };
 
-                let args = self.args[sep_pos + 1..].to_vec();
+                let args
+                    = self.args[sep_pos + 1..].to_vec();
+
                 return Some(BuiltinCommand::Complete { index, args });
             } else {
                 return Some(BuiltinCommand::Complete { index: 0, args: vec![] });

--- a/packages/clipanion-core/src/selector.rs
+++ b/packages/clipanion-core/src/selector.rs
@@ -316,6 +316,52 @@ impl<'cmds, 'args> Selector<'cmds, 'args> {
             return Ok(SelectionResult::Builtin(BuiltinCommand::Tokenize(self.args[1..].to_vec())));
         }
 
+        // Handle --clipanion-completion-script [--shell <shell>] [--command <command>]
+        if self.args.len() > 0 && self.args[0] == "--clipanion-completion-script" {
+            let mut shell = None;
+            let mut command = None;
+            let mut i = 1;
+            while i < self.args.len() {
+                match self.args[i] {
+                    "--shell" if i + 1 < self.args.len() => {
+                        shell = Some(self.args[i + 1].to_string());
+                        i += 2;
+                    }
+                    "--command" if i + 1 < self.args.len() => {
+                        command = Some(self.args[i + 1].to_string());
+                        i += 2;
+                    }
+                    _ => i += 1,
+                }
+            }
+            return Ok(SelectionResult::Builtin(BuiltinCommand::CompletionScript { shell, command }));
+        }
+
+        // Handle --clipanion-complete <index> -- <args...>
+        // The index is the 0-based position of the argument being completed
+        // Everything after -- is the user's command line (without binary name)
+        if self.args.len() > 0 && self.args[0] == "--clipanion-complete" {
+            // Find the -- separator
+            let separator_pos = self.args.iter().position(|&arg| arg == "--");
+
+            if let Some(sep_pos) = separator_pos {
+                // Parse index (should be at position 1)
+                let index = if sep_pos > 1 {
+                    self.args[1].parse::<usize>().unwrap_or(0)
+                } else {
+                    0
+                };
+
+                // Everything after -- is the user's arguments
+                let args = self.args[sep_pos + 1..].to_vec();
+
+                return Ok(SelectionResult::Builtin(BuiltinCommand::Complete { index, args }));
+            } else {
+                // Fallback: no separator, assume empty completion
+                return Ok(SelectionResult::Builtin(BuiltinCommand::Complete { index: 0, args: vec![] }));
+            }
+        }
+
         self.candidates = (0..self.states.len()).collect();
 
         self.prune_by_greediness();

--- a/packages/clipanion-demo/src/main.rs
+++ b/packages/clipanion-demo/src/main.rs
@@ -61,7 +61,9 @@ impl GitBranchCommand {
 
 fn complete_branch(ctx: &CompletionContext) -> Vec<Completion> {
     // In a real CLI, this would call `git branch --list` or similar.
-    let branches = ["main", "develop", "feature/login", "feature/search", "fix/typo"];
+    let branches
+        = ["main", "develop", "feature/login", "feature/search", "fix/typo"];
+
     branches.iter()
         .filter(|b| b.starts_with(ctx.current))
         .map(|b| Completion::new(*b))

--- a/packages/clipanion-demo/src/main.rs
+++ b/packages/clipanion-demo/src/main.rs
@@ -1,6 +1,7 @@
 use std::process::ExitCode;
 
 use clipanion::prelude::*;
+use clipanion::core::Completion;
 
 /// Add file contents to the index.
 ///
@@ -55,6 +56,38 @@ struct GitBranchCommand {
 impl GitBranchCommand {
     async fn execute(&self) {
         println!("Verbose: {}", self.verbose);
+    }
+}
+
+fn complete_branch(current: &str) -> Vec<Completion> {
+    // In a real CLI, this would call `git branch --list` or similar.
+    let branches = ["main", "develop", "feature/login", "feature/search", "fix/typo"];
+    branches.iter()
+        .filter(|b| b.starts_with(current))
+        .map(|b| Completion::new(*b))
+        .collect()
+}
+
+/// Switch branches or restore working tree files.
+#[cli::command]
+#[cli::path("checkout")]
+struct GitCheckoutCommand {
+    /// Create and checkout a new branch.
+    #[cli::option("-b", default = false)]
+    new_branch: bool,
+
+    /// The branch to checkout.
+    #[cli::positional(completer = complete_branch)]
+    branch: Option<String>,
+}
+
+impl GitCheckoutCommand {
+    async fn execute(&self) {
+        if self.new_branch {
+            println!("Creating and switching to branch {:?}", self.branch);
+        } else {
+            println!("Switching to branch {:?}", self.branch);
+        }
     }
 }
 
@@ -190,6 +223,7 @@ impl GitConfigSetCommand {
 enum MyCli {
     GitAdd(GitAddCommand),
     GitBranch(GitBranchCommand),
+    GitCheckout(GitCheckoutCommand),
     GitCommit(GitCommitCommand),
     GitConfigGet(GitConfigGetCommand),
     GitConfigList(GitConfigListCommand),

--- a/packages/clipanion-demo/src/main.rs
+++ b/packages/clipanion-demo/src/main.rs
@@ -1,7 +1,7 @@
 use std::process::ExitCode;
 
 use clipanion::prelude::*;
-use clipanion::core::Completion;
+use clipanion::core::{Completion, CompletionContext};
 
 /// Add file contents to the index.
 ///
@@ -59,11 +59,11 @@ impl GitBranchCommand {
     }
 }
 
-fn complete_branch(current: &str) -> Vec<Completion> {
+fn complete_branch(ctx: &CompletionContext) -> Vec<Completion> {
     // In a real CLI, this would call `git branch --list` or similar.
     let branches = ["main", "develop", "feature/login", "feature/search", "fix/typo"];
     branches.iter()
-        .filter(|b| b.starts_with(current))
+        .filter(|b| b.starts_with(ctx.current))
         .map(|b| Completion::new(*b))
         .collect()
 }

--- a/packages/clipanion-derive/src/macros/command.rs
+++ b/packages/clipanion-derive/src/macros/command.rs
@@ -471,6 +471,8 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                 .map(|lit| lit.value())
                 .unwrap_or_default();
 
+            let completer = positional_bag.take("completer");
+
             let field_name_upper = field.ident.as_ref().unwrap()
                 .to_string()
                 .to_uppercase();
@@ -496,6 +498,11 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                     #field_ident: partial.#field_ident,
                 });
 
+                let completer_expr = match &completer {
+                    Some(expr) => quote! { Some(#expr) },
+                    None => quote! { None },
+                };
+
                 builder.push(quote! {
                     command_spec.components.push(clipanion::core::Component::Positional(clipanion::core::PositionalSpec::Dynamic {
                         name: #field_name_upper.to_string(),
@@ -504,6 +511,7 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                         extra_len: None,
                         is_prefix: #is_prefix,
                         is_proxy: #is_proxy,
+                        completer: #completer_expr,
                     }));
                 });
             } else {
@@ -548,6 +556,11 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                     false => (quote!{1}, quote!{Some(0)}),
                 };
 
+                let completer_expr = match &completer {
+                    Some(expr) => quote! { Some(#expr) },
+                    None => quote! { None },
+                };
+
                 builder.push(quote! {
                     command_spec.components.push(clipanion::core::Component::Positional(clipanion::core::PositionalSpec::Dynamic {
                         name: #field_name_upper.to_string(),
@@ -556,6 +569,7 @@ pub fn command_macro(args: TokenStream, mut input: DeriveInput) -> Result<TokenS
                         extra_len: #extra_len,
                         is_prefix: #is_prefix,
                         is_proxy: false,
+                        completer: #completer_expr,
                     }));
                 });
             }

--- a/packages/clipanion/src/advanced.rs
+++ b/packages/clipanion/src/advanced.rs
@@ -239,10 +239,10 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
 
         BuiltinCommand::CompletionScript { shell, command } => {
             // Determine the shell to use
-            let shell = shell
-                .as_ref()
-                .and_then(|s| Shell::from_str(s))
-                .or_else(Shell::detect);
+            let shell
+                = shell.as_ref()
+                    .and_then(|s| Shell::from_str(s))
+                    .or_else(Shell::detect);
 
             let Some(shell) = shell else {
                 eprintln!("Could not detect shell. Please specify with --shell <bash|zsh|fish>");
@@ -250,20 +250,25 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
             };
 
             // Use the provided command or default to the binary name
-            let command = command
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or(&env.info.binary_name);
+            let command
+                = command.as_ref()
+                    .map(|s| s.as_str())
+                    .unwrap_or(&env.info.binary_name);
 
-            let script = generate_completion_script(shell, command);
+            let script
+                = generate_completion_script(shell, command);
+
             println!("{}", script);
 
             Ok(std::process::ExitCode::SUCCESS)
         },
 
         BuiltinCommand::Complete { index, args } => {
-            let commands = S::registered_commands()?;
-            let machine = builder.compile();
+            let commands
+                = S::registered_commands()?;
+
+            let machine
+                = builder.compile();
 
             // Convert index + args into before/current
             let (before, current) = if args.is_empty() {
@@ -275,8 +280,11 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
                 (args[..index].to_vec(), args[index])
             };
 
-            let context = CompletionContext::new(before, current);
-            let result = compute_completions(&commands, &machine, &context);
+            let context
+                = CompletionContext::new(before, current);
+
+            let result
+                = compute_completions(&commands, &machine, &context);
 
             // Output completions, one per line (tab-separated with description if available)
             for completion in result.completions {

--- a/packages/clipanion/src/advanced.rs
+++ b/packages/clipanion/src/advanced.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, future::Future};
 
-use clipanion_core::{BuiltinCommand, CliBuilder, Info, SelectionResult};
+use clipanion_core::{BuiltinCommand, CliBuilder, CompletionContext, Info, SelectionResult, Shell, compute_completions, generate_completion_script};
 
 use crate::{details::{CliEnums, CommandExecutor, CommandExecutorAsync, CommandProvider}, format::{write_color, write_fading_title_line, Formatter}};
 
@@ -224,6 +224,58 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
             }
 
             print!("{}", output_string);
+
+            Ok(std::process::ExitCode::SUCCESS)
+        },
+
+        BuiltinCommand::CompletionScript { shell, command } => {
+            // Determine the shell to use
+            let shell = shell
+                .as_ref()
+                .and_then(|s| Shell::from_str(s))
+                .or_else(Shell::detect);
+
+            let Some(shell) = shell else {
+                eprintln!("Could not detect shell. Please specify with --shell <bash|zsh|fish>");
+                return Err(clipanion_core::Error::InternalError);
+            };
+
+            // Use the provided command or default to the binary name
+            let command = command
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or(&env.info.binary_name);
+
+            let script = generate_completion_script(shell, command);
+            println!("{}", script);
+
+            Ok(std::process::ExitCode::SUCCESS)
+        },
+
+        BuiltinCommand::Complete { index, args } => {
+            let commands = S::registered_commands()?;
+            let machine = builder.compile();
+
+            // Convert index + args into before/current/after
+            let (before, current, after) = if args.is_empty() {
+                (vec![], "", vec![])
+            } else if index >= args.len() {
+                // Cursor is after all args (completing a new argument)
+                (args.iter().map(|s| *s).collect(), "", vec![])
+            } else {
+                let before: Vec<&str> = args[..index].to_vec();
+                let current = args[index];
+                let after: Vec<&str> = args[index + 1..].to_vec();
+                (before, current, after)
+            };
+
+            let context = CompletionContext::new(before, current, after, current.len());
+            let result = compute_completions(&commands, &machine, &context);
+
+            // Output completions, one per line (simple format for shell consumption)
+            for completion in result.completions {
+                println!("{}", completion.text);
+            }
 
             Ok(std::process::ExitCode::SUCCESS)
         },

--- a/packages/clipanion/src/advanced.rs
+++ b/packages/clipanion/src/advanced.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, future::Future};
 
-use clipanion_core::{BuiltinCommand, CliBuilder, CompletionContext, Info, SelectionResult, Shell, compute_completions, generate_completion_script};
+use clipanion_core::{BuiltinCommand, CliBuilder, CompletionContext, Info, SelectionResult, Shell, compute_completions, generate_completion_script, is_completion_enabled};
 
 use crate::{details::{CliEnums, CommandExecutor, CommandExecutorAsync, CommandProvider}, format::{write_color, write_fading_title_line, Formatter}};
 
@@ -223,6 +223,15 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
                 }
             }
 
+            if !is_completion_enabled(&env.info.binary_name) {
+                output_string.push('\n');
+                write_color(&mut output_string, (128, 128, 128));
+                output_string.push_str(&format!(
+                    "Tip: Shell completions are available. Run `{} --clipanion-completion-script` to generate the setup script.\x1b[0m\n",
+                    env.info.binary_name,
+                ));
+            }
+
             print!("{}", output_string);
 
             Ok(std::process::ExitCode::SUCCESS)
@@ -256,25 +265,26 @@ fn handle_builtin<'cmds, 'args, S: CliEnums + CommandProvider>(builder: &CliBuil
             let commands = S::registered_commands()?;
             let machine = builder.compile();
 
-            // Convert index + args into before/current/after
-            let (before, current, after) = if args.is_empty() {
-                (vec![], "", vec![])
+            // Convert index + args into before/current
+            let (before, current) = if args.is_empty() {
+                (vec![], "")
             } else if index >= args.len() {
                 // Cursor is after all args (completing a new argument)
-                (args.iter().map(|s| *s).collect(), "", vec![])
+                (args.iter().map(|s| *s).collect(), "")
             } else {
-                let before: Vec<&str> = args[..index].to_vec();
-                let current = args[index];
-                let after: Vec<&str> = args[index + 1..].to_vec();
-                (before, current, after)
+                (args[..index].to_vec(), args[index])
             };
 
-            let context = CompletionContext::new(before, current, after, current.len());
+            let context = CompletionContext::new(before, current);
             let result = compute_completions(&commands, &machine, &context);
 
-            // Output completions, one per line (simple format for shell consumption)
+            // Output completions, one per line (tab-separated with description if available)
             for completion in result.completions {
-                println!("{}", completion.text);
+                if let Some(desc) = &completion.description {
+                    println!("{}\t{}", completion.text, desc);
+                } else {
+                    println!("{}", completion.text);
+                }
             }
 
             Ok(std::process::ExitCode::SUCCESS)


### PR DESCRIPTION
This PR attempts to implement native completion capabilities for Clipanion-generated CLIs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new framework-internal flags and a full completion engine that affects argument selection (notably with proxy positionals) and CLI output, so regressions could impact command parsing or help behavior across CLIs.
> 
> **Overview**
> Adds first-class shell completion support to Clipanion-generated CLIs. This introduces new internal builtins `--clipanion-completion-script` (bash/zsh/fish script generator) and `--clipanion-complete` (returns context-aware completion candidates), plus a new `clipanion-core` completion engine that suggests command path segments, long options (filtering already-used single-use options), and optional positional completions via user-provided completer functions.
> 
> Extends `PositionalSpec::Dynamic` with an optional `completer` callback (wired through the derive macro via `#[cli::positional(completer = ...)]`), exports the new `completion` module from `clipanion-core`, and updates selection to intercept `--clipanion-*` flags *before* normal parsing to prevent proxy commands from swallowing them. The demo CLI is updated with a `checkout` command showcasing positional completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 372b3055dcca4ee735227fc7fa3cb1ad51d5d769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->